### PR TITLE
Fix the filename of the build output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {


### PR DESCRIPTION
Currently we rely on the information returned by the server in order to set the filename of the build output (.apk, .ipa..). However currently it does not work correctly and returns `undefined.apk`. Get back the previous code, which sets the name correctly.