### PR TITLE
Fix cloud builds

### DIFF
--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -185,8 +185,9 @@ export class CloudBuildService implements ICloudBuildService {
 
 	}
 
-	private async uploadFileToS3(projectId: string, localFilePath: string, extension: string = ""): Promise<IAmazonStorageEntryData> {
-		const fileNameInS3 = uuid.v4() + extension;
+	private async uploadFileToS3(projectId: string, localFilePath: string, fileNameInS3?: string): Promise<IAmazonStorageEntryData> {
+		fileNameInS3 = fileNameInS3 || uuid.v4();
+		console.log("Uploading " + localFilePath + " with name: ", fileNameInS3);
 		const preSignedUrlData = await this.$server.appsBuild.getPresignedUploadUrlObject(projectId, fileNameInS3);
 
 		const requestOpts: any = {
@@ -242,8 +243,9 @@ export class CloudBuildService implements ICloudBuildService {
 		iOSBuildData: IIOSBuildData): Promise<any> {
 
 		if (iOSBuildData.buildForDevice) {
+			const provisionData = this.getMobileProvisionData(iOSBuildData.pathToProvision);
 			const certificateS3Data = await this.uploadFileToS3(projectSettings.projectId, iOSBuildData.pathToCertificate);
-			const provisonS3Data = await this.uploadFileToS3(projectSettings.projectId, iOSBuildData.pathToProvision, ".mobileprovision");
+			const provisonS3Data = await this.uploadFileToS3(projectSettings.projectId, iOSBuildData.pathToProvision, `${provisionData.UUID}.mobileprovision`);
 
 			buildProps.BuildFiles.push(
 				{
@@ -258,7 +260,7 @@ export class CloudBuildService implements ICloudBuildService {
 
 			buildProps.Properties.CertificatePassword = iOSBuildData.certificatePassword;
 			buildProps.Properties.CodeSigningIdentity = this.getCertificateInfo(iOSBuildData.pathToCertificate, iOSBuildData.certificatePassword).commonName;
-			const provisionData = this.getMobileProvisionData(iOSBuildData.pathToProvision);
+
 			const cloudProvisionsData: any[] = [{
 				SuffixId: "",
 				TemplateName: "PROVISION_",

--- a/lib/services/service-proxy.ts
+++ b/lib/services/service-proxy.ts
@@ -1,7 +1,6 @@
 
 export class ServiceProxy implements CloudService.IServiceProxy {
 	constructor(protected $httpClient: Server.IHttpClient,
-		private $packageInfoService: IPackageInfoService,
 		protected $logger: ILogger,
 		protected $serverConfig: IServerConfiguration,
 		protected $errors: IErrors) {
@@ -11,7 +10,6 @@ export class ServiceProxy implements CloudService.IServiceProxy {
 		path = `appbuilder/${path}`;
 		headers = headers || Object.create(null);
 		headers["X-Icenium-SolutionSpace"] = headers["X-Icenium-SolutionSpace"] || "Private_Build_Folder";
-		headers["User-Agent"] = `fusion/${this.$packageInfoService.getVersion()} (Node.js ${process.versions.node}; ${process.platform}; ${process.arch})`;
 
 		if (accept) {
 			headers.Accept = accept;

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "cookie": "0.3.1",
     "lodash": "4.17.4",
+    "minimatch": "3.0.4",
     "node-forge": "0.7.0",
     "querystring": "0.2.0",
     "semver": "5.3.0",


### PR DESCRIPTION
### Pass ProjectName to cloud build
The ProjectName should be passed to Cloud Builds in order to generate correct output filename. In case it is not passed, the name is "undefined.apk", "undefined.ipa", etc.
Remove some obsolete comments.

### 	Pass the UUID of provision as a filename when uploading to S3
For mobileprovisions we need the filename in S3 to be `<UUID of provision>.mobileprovision`, so make sure the name is this one.

### 	Fix getting project files for cloud build
Fix getting project project files for cloud builds - ignore all hidden files and include .ts files.