### PR TITLE
Introduce appetizeDeviceDiscovery

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -211,7 +211,8 @@ module.exports = function (grunt) {
 
 		const pathsOfDtsFiles = getReferencesFromDir(path.join(nodeModulesDirPath, nativescript))
 			.concat(getReferencesFromDir(path.join(nodeModulesDirPath, "mobile-cli-lib")))
-			.concat(getReferencesFromDir(pathToIosDeviceLib));
+			.concat(getReferencesFromDir(pathToIosDeviceLib))
+			.concat(getReferencesFromDir(path.join(nodeModulesDirPath, "cloud-device-emulator")));
 
 		const lines = pathsOfDtsFiles.map(file => `/// <reference path="${fromWindowsRelativePathToUnix(path.relative(__dirname, file))}" />`);
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,58 @@ tns.cloudBuildService
 	.catch(err => console.error("Data is invalid:", err));
 ```
 
+### Module appetizeEmulatorLauncher
+The `appetizeEmulatorLauncher` provides a way for initial interaction with appetize emulators. You can call the following methods:
+* `startEmulator` method - starts an appetize emulator and returns a url where an html page is located, containing an iframe with the actual emulator. </br>
+Definition:
+
+```TypeScript
+/**
+ * Describes options that can be passed when starting an appetize emulator.
+ */
+interface IAppetizeEmulatorStartData {
+	/**
+	 * Path to the package file (.apk or .zip) to load - can either be a local path or a url.
+	 */
+	packageFile: string;
+	/**
+	 * Platform for the emulator - android or ios
+	 */
+	platform: string;
+	/**
+	 * Model of the emulator - for example nexus5, iphone5s, iphone6 - etc
+	 */
+	model: string;
+}
+
+/**
+ * Describes service for initial interaction with appetize emulators.
+ */
+interface IAppetizeEmulatorLauncher {
+	/**
+	 * Starts an appetize emulator.
+	 * @param {IAppetizeEmulatorStartData} data Options for starting emulator.
+	 * @param optional {IConfigOptions} options The config options.
+	 * @returns {string} A url containing an html page with the emulator inside an iframe. The url's host is localhost.
+	 */
+	startEmulator(data: IAppetizeEmulatorStartData): Promise<string>;
+}
+
+```
+Usage:
+```JavaScript
+const tns = require("nativescript");
+
+tns.appetizeEmulatorLauncher.startEmulator({
+			packageFile: "test.apk",
+			platform: "android",
+			model: "nexus5"
+		}).then(address => {
+			console.log("address is", address);
+			// http://localhost:56760/?publicKey=somekey&device=nexus5
+		});
+```
+
 ### Module authenticationService
 The `authenticationService` is used for authentication related operations (login, logout etc.). You can call the following methods </br>
 * `login` - Starts localhost server on which the login response will be returned. After that if there is `options.openAction` it will be used to open the login url. If this option is not defined the default opener will be used. After successful login returns the user information.
@@ -200,7 +252,7 @@ Definition:
 
 ```TypeScript
 /**
- * Uses the refresh token of the current user to issue new access token. 
+ * Uses the refresh token of the current user to issue new access token.
  */
 refreshCurrentUserToken(): Promise<void>;
 ```
@@ -248,7 +300,7 @@ interface IAuthenticationService {
 	logout(): void;
 
 	/**
-	 * Uses the refresh token of the current user to issue new access token. 
+	 * Uses the refresh token of the current user to issue new access token.
 	 */
 	refreshCurrentUserToken(): Promise<void>;
 

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -4,6 +4,7 @@ $injector.require("httpServer", path.join(__dirname, "http-server"));
 $injector.require("itmsServicesPlistHelper", path.join(__dirname, "itms-services-plist-helper"));
 $injector.require("serverConfigManager", path.join(__dirname, "server-config-manager"));
 $injector.require("cloudBuildOutputFilter", path.join(__dirname, "cloud-build-output-filter"));
+$injector.require("cloudDeviceEmulator", path.join(__dirname, "cloud-device-emulator"));
 
 // Mobile.
 $injector.require("appetizeDeviceDiscovery", path.join(__dirname, "mobile", "mobile-core", "appetize-device-discovery"));

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -5,15 +5,21 @@ $injector.require("itmsServicesPlistHelper", path.join(__dirname, "itms-services
 $injector.require("serverConfigManager", path.join(__dirname, "server-config-manager"));
 $injector.require("cloudBuildOutputFilter", path.join(__dirname, "cloud-build-output-filter"));
 
+// Mobile.
+$injector.require("appetizeDeviceDiscovery", path.join(__dirname, "mobile", "mobile-core", "appetize-device-discovery"));
+
 // Public API.
 $injector.requirePublicClass("authenticationService", path.join(__dirname, "services", "authentication-service"));
 $injector.requirePublicClass("cloudBuildService", path.join(__dirname, "services", "cloud-build-service"));
+$injector.requirePublicClass("appetizeEmulatorLauncher", path.join(__dirname, "services", "appetize-emulator-launcher"));
 
 // Services.
+$injector.require("uploadService", path.join(__dirname, "services", "cloud-services", "upload-service"));
 $injector.require("authCloudService", path.join(__dirname, "services", "cloud-services", "auth-cloud-service"));
 $injector.require("buildCloudService", path.join(__dirname, "services", "cloud-services", "build-cloud-service"));
 $injector.require("cloudServicesProxy", path.join(__dirname, "services", "cloud-services", "cloud-services-proxy"));
 $injector.require("cloudRequestService", path.join(__dirname, "services", "cloud-services", "cloud-request-service"));
+$injector.require("cloudEmulatorService", path.join(__dirname, "services", "cloud-services", "cloud-emulator-service"));
 $injector.require("packageInfoService", path.join(__dirname, "services", "package-info-service"));
 $injector.require("userService", path.join(__dirname, "services", "user-service"));
 
@@ -31,3 +37,6 @@ $injector.requireCommand("user", path.join(__dirname, "commands", "user"));
 
 $injector.requireCommand("build|cloud", path.join(__dirname, "commands", "cloud-build"));
 $injector.requireCommand("cloud|lib|version", path.join(__dirname, "commands", "cloud-lib-version"));
+
+const $devicesService: Mobile.IDevicesService = $injector.resolve("devicesService");
+$devicesService.addDeviceDiscovery($injector.resolve("appetizeDeviceDiscovery"));

--- a/lib/cloud-device-emulator.ts
+++ b/lib/cloud-device-emulator.ts
@@ -1,0 +1,21 @@
+export class CloudDeviceEmulatorWrapper implements ICloudDeviceEmulator {
+	private cloudDeviceEmulatorInstance: ICloudDeviceEmulator;
+
+	public get deviceEmitter(): CloudDeviceEmitter {
+		return this.cloudDeviceEmulatorInstance.deviceEmitter;
+	}
+
+	constructor() {
+		this.cloudDeviceEmulatorInstance = require("cloud-device-emulator");
+	}
+
+	public getSeverAddress(): Promise<ICloudDeviceServerInfo> {
+		return this.cloudDeviceEmulatorInstance.getSeverAddress();
+	}
+
+	public refresh(deviceIdentifier: string): Promise<void> {
+		return this.cloudDeviceEmulatorInstance.refresh(deviceIdentifier);
+	}
+}
+
+$injector.register("cloudDeviceEmulator", CloudDeviceEmulatorWrapper);

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -27,6 +27,17 @@ export const CLOUD_BUILD_EVENT_NAMES = {
 	OUTPUT: "output"
 };
 
+export const DEVICE_DISCOVERY_EVENTS = {
+	DEVICE_FOUND: "deviceFound",
+	DEVICE_LOST: "deviceLost"
+};
+
+export const DEVICE_INFO = {
+	TYPE: "Emulator",
+	STATUS: "Connected",
+	VENDOR: "Appetize"
+};
+
 export const CONTENT_TYPES = {
 	APPLICATION_JSON: "application/json",
 	TEXT_HTML: "text/html",

--- a/lib/definitions/cloud-services/cloud-services.d.ts
+++ b/lib/definitions/cloud-services/cloud-services.d.ts
@@ -14,11 +14,13 @@ interface IUploadService {
 	updloadToS3(localFilePath: string): Promise<string>;
 }
 
+interface IEmulatorCredentials {
+	[key: string]: ICloudEmulatorKeys;
+}
+
 interface ICloudEmulatorService {
 	startEmulator(publicKey: string, platform: string, deviceType: string): Promise<any>;
-	createApp(url: string, platform: string, ): Promise<ICloudEmulatorResponse>;
-	updateApp(url: string, platform: string, publicKey: string, privateKey: string): Promise<ICloudEmulatorResponse>;
-	deployApp(fileName: string, platform: string): Promise<ICloudEmulatorResponse>;
+	deployApp(fileLocation: string, platform: string): Promise<ICloudEmulatorResponse>;
 	refereshEmulator(deviceIdentifier: string): Promise<void>;
 }
 
@@ -27,7 +29,7 @@ interface IAmazonStorageEntryData extends IAmazonStorageEntry {
 }
 
 interface ICloudEmulatorResponse {
-	appPermissions: {};
+	appPermissions: any;
 	appURL: string;
 	architectures: [string];
 	created: Date;

--- a/lib/definitions/cloud-services/cloud-services.d.ts
+++ b/lib/definitions/cloud-services/cloud-services.d.ts
@@ -10,6 +10,49 @@ interface ICloudServicesProxy extends ICloudRequestService {
 	getUrlPath(serviceName: string, urlPath: string): string;
 }
 
+interface IUploadService {
+	updloadToS3(localFilePath: string): Promise<string>;
+}
+
+interface ICloudEmulatorService {
+	startEmulator(publicKey: string, platform: string, deviceType: string): Promise<any>;
+	createApp(url: string, platform: string, ): Promise<ICloudEmulatorResponse>;
+	updateApp(url: string, platform: string, publicKey: string, privateKey: string): Promise<ICloudEmulatorResponse>;
+	deployApp(fileName: string, platform: string): Promise<ICloudEmulatorResponse>;
+	refereshEmulator(deviceIdentifier: string): Promise<void>;
+}
+
+interface IAmazonStorageEntryData extends IAmazonStorageEntry {
+	fileNameInS3: string;
+}
+
+interface ICloudEmulatorResponse {
+	appPermissions: {};
+	appURL: string;
+	architectures: [string];
+	created: Date;
+	email: string;
+	manageURL: string;
+	platform: string;
+	privateKey: string;
+	publicKey: string;
+	publicURL: string;
+	updated: Date;
+	versionCode: Number;
+}
+
+interface IPresignURLResponse {
+	uploadPreSignedUrl: string;
+	publicDownloadUrl: string;
+	s3Url: string;
+	sessionKey: string;
+}
+
+interface ICloudEmulatorKeys {
+	publicKey: string;
+	privateKey: string;
+}
+
 interface ICloudRequestService {
 	call<T>(options: ICloudRequestOptions): Promise<T>;
 }

--- a/lib/definitions/emulators.d.ts
+++ b/lib/definitions/emulators.d.ts
@@ -1,9 +1,30 @@
+/**
+ * Describes options that can be passed when starting an appetize emulator.
+ */
 interface IAppetizeEmulatorStartData {
+	/**
+	 * Path to the package file (.apk or .zip) to load - can either be a local path or a url.
+	 */
 	packageFile: string;
+	/**
+	 * Platform for the emulator - android or ios
+	 */
 	platform: string;
+	/**
+	 * Model of the emulator - for example nexus5, iphone5s, iphone6 - etc
+	 */
 	model: string;
 }
 
+/**
+ * Describes service for initial interaction with appetize emulators.
+ */
 interface IAppetizeEmulatorLauncher {
+	/**
+	 * Starts an appetize emulator.
+	 * @param {IAppetizeEmulatorStartData} data Options for starting emulator.
+	 * @param optional {IConfigOptions} options The config options.
+	 * @returns {string} A url containing an html page with the emulator inside an iframe. The url's host is localhost.
+	 */
 	startEmulator(data: IAppetizeEmulatorStartData): Promise<string>;
 }

--- a/lib/definitions/emulators.d.ts
+++ b/lib/definitions/emulators.d.ts
@@ -28,3 +28,26 @@ interface IAppetizeEmulatorLauncher {
 	 */
 	startEmulator(data: IAppetizeEmulatorStartData): Promise<string>;
 }
+
+/**
+ * Describes service for interaction with server which communicates with cloud emulators.
+ */
+interface ICloudDeviceEmulator {
+	/**
+	 * Event emitter instance that raises events upon finding/losing a device.
+	 */
+	deviceEmitter: CloudDeviceEmitter;
+
+	/**
+	 * Retrieves information about the currently running server for communication with cloud emulators.
+	 * @returns {Promise<ICloudDeviceServerInfo>} Information about the server.
+	 */
+	getSeverAddress(): Promise<ICloudDeviceServerInfo>;
+
+	/**
+	 * Refreshes a cloud emulator.
+	 * @param {string} deviceIdentifier The device's identifier.
+	 * @returns {Promise<void>}
+	 */
+	refresh(deviceIdentifier: string): Promise<void>;
+}

--- a/lib/definitions/emulators.d.ts
+++ b/lib/definitions/emulators.d.ts
@@ -1,0 +1,9 @@
+interface IAppetizeEmulatorStartData {
+	packageFile: string;
+	platform: string;
+	model: string;
+}
+
+interface IAppetizeEmulatorLauncher {
+	startEmulator(data: IAppetizeEmulatorStartData): Promise<string>;
+}

--- a/lib/mobile/device/appetize-application-manager.ts
+++ b/lib/mobile/device/appetize-application-manager.ts
@@ -26,8 +26,8 @@ export class AppetizeApplicationManager extends EventEmitter implements Mobile.I
 
 	public async stopApplication(appIdentifier: string): Promise<void> { /* currently empty */ }
 
-	public getApplicationInfo(applicationIdentifier: string): Promise<Mobile.IApplicationInfo> {
-		return Promise.resolve(null);
+	public async getApplicationInfo(applicationIdentifier: string): Promise<Mobile.IApplicationInfo> {
+		return null;
 	}
 
 	public canStartApplication(): boolean {

--- a/lib/mobile/device/appetize-application-manager.ts
+++ b/lib/mobile/device/appetize-application-manager.ts
@@ -1,0 +1,58 @@
+import { EventEmitter } from "events";
+
+export class AppetizeApplicationManager extends EventEmitter implements Mobile.IDeviceApplicationManager {
+
+	constructor(private basicInfo: IAppetizeDeviceBasicInfo,
+		private $cloudEmulatorService: ICloudEmulatorService) {
+		super();
+	}
+
+	public async getInstalledApplications(): Promise<string[]> {
+		return [];
+	}
+
+	public async installApplication(packageFilePath: string): Promise<void> {
+		await this.$cloudEmulatorService.deployApp(packageFilePath, this.basicInfo.os);
+		return this.$cloudEmulatorService.refereshEmulator(this.basicInfo.identifier);
+	}
+
+	public async isApplicationInstalled(appIdentifier: string): Promise<boolean> {
+		return true;
+	}
+
+	public async uninstallApplication(appIdentifier: string): Promise<void> { /* currently empty */ }
+
+	public async startApplication(appIdentifier: string): Promise<void> { /* currently empty */ }
+
+	public async stopApplication(appIdentifier: string): Promise<void> { /* currently empty */ }
+
+	public getApplicationInfo(applicationIdentifier: string): Promise<Mobile.IApplicationInfo> {
+		return Promise.resolve(null);
+	}
+
+	public canStartApplication(): boolean {
+		return true;
+	}
+
+	public async isLiveSyncSupported(appIdentifier: string): Promise<boolean> {
+		return false;
+	}
+
+	public async getDebuggableApps(): Promise<Mobile.IDeviceApplicationInformation[]> {
+		return [];
+	}
+
+	public async getDebuggableAppViews(appIdentifiers: string[]): Promise<IDictionary<Mobile.IDebugWebViewInfo[]>> {
+		return {};
+	}
+
+	public async reinstallApplication(appIdentifier: string, packageFilePath: string): Promise<void> {
+		return this.installApplication(packageFilePath);
+	}
+
+	public async restartApplication(appIdentifier: string, appName?: string): Promise<void> { /* currently empty */ }
+
+	public async checkForApplicationUpdates(): Promise<void> { /* currently empty */ }
+
+	public async tryStartApplication(appIdentifier: string): Promise<void> { /* currently empty */ }
+}

--- a/lib/mobile/device/appetize-device-file-system.ts
+++ b/lib/mobile/device/appetize-device-file-system.ts
@@ -1,0 +1,15 @@
+export class AppetizeDeviceFileSystem implements Mobile.IDeviceFileSystem {
+	public async listFiles(devicePath: string, appIdentifier?: string): Promise<any> { /* currently empty */ }
+
+	public async getFile(deviceFilePath: string, appIdentifier: string, outputPath?: string): Promise<void> { /* currently empty */ }
+
+	public async putFile(localFilePath: string, deviceFilePath: string, appIdentifier: string): Promise<void> { /* currently empty */ }
+
+	public async transferFiles(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]): Promise<void> { /* currently empty */ }
+
+	public async transferDirectory(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string): Promise<void> { /* currently empty */ }
+
+	public async transferFile(localPath: string, devicePath: string): Promise<void> { /* currently empty */ }
+
+	public async createFileOnDevice(deviceFilePath: string, fileContent: string): Promise<void> { /* currently empty */ }
+}

--- a/lib/mobile/device/appetize-device.ts
+++ b/lib/mobile/device/appetize-device.ts
@@ -31,7 +31,7 @@ export class AppetizeDevice implements Mobile.IDevice {
 
 	private init(): void {
 		this.applicationManager = this.$injector.resolve(AppetizeApplicationManager, { basicInfo: this.basicInfo });
-		this.fileSystem = this.$injector.resolve(AppetizeDeviceFileSystem, {});
+		this.fileSystem = this.$injector.resolve(AppetizeDeviceFileSystem);
 		this.deviceInfo = {
 			identifier: this.basicInfo.identifier,
 			model: this.basicInfo.model,

--- a/lib/mobile/device/appetize-device.ts
+++ b/lib/mobile/device/appetize-device.ts
@@ -1,0 +1,48 @@
+import { AppetizeApplicationManager } from "./appetize-application-manager";
+import { AppetizeDeviceFileSystem } from "./appetize-device-file-system";
+import { DEVICE_INFO } from "../../constants";
+
+export class AppetizeDevice implements Mobile.IDevice {
+	public applicationManager: Mobile.IDeviceApplicationManager;
+	public fileSystem: Mobile.IDeviceFileSystem;
+	public deviceInfo: Mobile.IDeviceInfo;
+
+	constructor(private basicInfo: IAppetizeDeviceBasicInfo,
+		private $mobileHelper: Mobile.IMobileHelper,
+		private $injector: IInjector) {
+		this.init();
+	}
+
+	public get isEmulator(): boolean {
+		return true;
+	}
+
+	public async openDeviceLogStream(): Promise<void> { /* currently empty */ }
+
+	public getApplicationInfo(applicationIdentifier: string): Promise<Mobile.IApplicationInfo> {
+		const deviceInfo: Mobile.IApplicationInfo = {
+			applicationIdentifier: applicationIdentifier,
+			deviceIdentifier: this.basicInfo.identifier,
+			configuration: "debug"
+		};
+
+		return Promise.resolve(deviceInfo);
+	}
+
+	private init(): void {
+		this.applicationManager = this.$injector.resolve(AppetizeApplicationManager, { basicInfo: this.basicInfo });
+		this.fileSystem = this.$injector.resolve(AppetizeDeviceFileSystem, {});
+		this.deviceInfo = {
+			identifier: this.basicInfo.identifier,
+			model: this.basicInfo.model,
+			platform: this.$mobileHelper.normalizePlatformName(this.basicInfo.os),
+			isTablet: false,
+			displayName: this.basicInfo.model,
+			version: "",
+			vendor: DEVICE_INFO.VENDOR,
+			type: DEVICE_INFO.TYPE,
+			errorHelp: "",
+			status: DEVICE_INFO.STATUS
+		};
+	}
+}

--- a/lib/mobile/mobile-core/appetize-device-discovery.ts
+++ b/lib/mobile/mobile-core/appetize-device-discovery.ts
@@ -1,0 +1,60 @@
+import { EventEmitter } from "events";
+import { DEVICE_DISCOVERY_EVENTS } from "../../constants";
+import { deviceEmitter } from "cloud-device-emulator";
+import { AppetizeDevice } from "../device/appetize-device";
+import { values } from "lodash";
+
+export class AppetizeDeviceDiscovery extends EventEmitter implements Mobile.IDeviceDiscovery {
+	private devices: IDictionary<Mobile.IDevice> = {};
+
+	constructor(private $injector: IInjector) {
+		super();
+	}
+
+	public addDevice(device: Mobile.IDevice) {
+		this.devices[device.deviceInfo.identifier] = device;
+		this.raiseOnDeviceFound(device);
+	}
+
+	public removeDevice(deviceIdentifier: string) {
+		let device = this.devices[deviceIdentifier];
+		if (!device) {
+			return;
+		}
+
+		delete this.devices[deviceIdentifier];
+		this.raiseOnDeviceLost(device);
+	}
+
+	public async startLookingForDevices(): Promise<void> {
+		values(deviceEmitter.getCurrentlyAttachedDevices()).forEach(basicInfo => {
+			this.addAppetizeDevice(basicInfo);
+		});
+
+		deviceEmitter.on(DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND, (basicInfo: IAppetizeDeviceBasicInfo) => {
+			this.addAppetizeDevice(basicInfo);
+		});
+
+		deviceEmitter.on(DEVICE_DISCOVERY_EVENTS.DEVICE_LOST, (basicInfo: IAppetizeDeviceBasicInfo) => {
+			const device: Mobile.IDevice = this.$injector.resolve(AppetizeDevice, { basicInfo: basicInfo });
+			this.removeDevice(device.deviceInfo.identifier);
+		});
+	}
+
+	public async checkForDevices(): Promise<void> { /* currently empty */ }
+
+	private raiseOnDeviceFound(device: Mobile.IDevice) {
+		this.emit(DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND, device);
+	}
+
+	private raiseOnDeviceLost(device: Mobile.IDevice) {
+		this.emit(DEVICE_DISCOVERY_EVENTS.DEVICE_LOST, device);
+	}
+
+	private addAppetizeDevice(basicInfo: IAppetizeDeviceBasicInfo) {
+		const device: Mobile.IDevice = this.$injector.resolve(AppetizeDevice, { basicInfo: basicInfo });
+		this.addDevice(device);
+	}
+}
+
+$injector.register("appetizeDeviceDiscovery", AppetizeDeviceDiscovery);

--- a/lib/mobile/mobile-core/appetize-device-discovery.ts
+++ b/lib/mobile/mobile-core/appetize-device-discovery.ts
@@ -1,13 +1,13 @@
 import { EventEmitter } from "events";
 import { DEVICE_DISCOVERY_EVENTS } from "../../constants";
-import { deviceEmitter } from "cloud-device-emulator";
 import { AppetizeDevice } from "../device/appetize-device";
 
 export class AppetizeDeviceDiscovery extends EventEmitter implements Mobile.IDeviceDiscovery {
 	private devices: IDictionary<Mobile.IDevice> = {};
 	private _hasStartedLookingForDevices = false;
 
-	constructor(private $injector: IInjector) {
+	constructor(private $cloudDeviceEmulator: ICloudDeviceEmulator,
+		private $injector: IInjector) {
 		super();
 	}
 
@@ -29,15 +29,15 @@ export class AppetizeDeviceDiscovery extends EventEmitter implements Mobile.IDev
 	public async startLookingForDevices(): Promise<void> {
 		if (!this._hasStartedLookingForDevices) {
 			this._hasStartedLookingForDevices = true;
-			_.values(deviceEmitter.getCurrentlyAttachedDevices()).forEach(basicInfo => {
+			_.values(this.$cloudDeviceEmulator.deviceEmitter.getCurrentlyAttachedDevices()).forEach(basicInfo => {
 				this.addAppetizeDevice(basicInfo);
 			});
 
-			deviceEmitter.on(DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND, (basicInfo: IAppetizeDeviceBasicInfo) => {
+			this.$cloudDeviceEmulator.deviceEmitter.on(DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND, (basicInfo: IAppetizeDeviceBasicInfo) => {
 				this.addAppetizeDevice(basicInfo);
 			});
 
-			deviceEmitter.on(DEVICE_DISCOVERY_EVENTS.DEVICE_LOST, (basicInfo: IAppetizeDeviceBasicInfo) => {
+			this.$cloudDeviceEmulator.deviceEmitter.on(DEVICE_DISCOVERY_EVENTS.DEVICE_LOST, (basicInfo: IAppetizeDeviceBasicInfo) => {
 				this.removeDevice(basicInfo.identifier);
 			});
 		}

--- a/lib/mobile/mobile-core/appetize-device-discovery.ts
+++ b/lib/mobile/mobile-core/appetize-device-discovery.ts
@@ -6,6 +6,7 @@ import { values } from "lodash";
 
 export class AppetizeDeviceDiscovery extends EventEmitter implements Mobile.IDeviceDiscovery {
 	private devices: IDictionary<Mobile.IDevice> = {};
+	private _hasStartedLookingForDevices = false;
 
 	constructor(private $injector: IInjector) {
 		super();
@@ -27,18 +28,21 @@ export class AppetizeDeviceDiscovery extends EventEmitter implements Mobile.IDev
 	}
 
 	public async startLookingForDevices(): Promise<void> {
-		values(deviceEmitter.getCurrentlyAttachedDevices()).forEach(basicInfo => {
-			this.addAppetizeDevice(basicInfo);
-		});
+		if (!this._hasStartedLookingForDevices) {
+			this._hasStartedLookingForDevices = true;
+			values(deviceEmitter.getCurrentlyAttachedDevices()).forEach(basicInfo => {
+				this.addAppetizeDevice(basicInfo);
+			});
 
-		deviceEmitter.on(DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND, (basicInfo: IAppetizeDeviceBasicInfo) => {
-			this.addAppetizeDevice(basicInfo);
-		});
+			deviceEmitter.on(DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND, (basicInfo: IAppetizeDeviceBasicInfo) => {
+				this.addAppetizeDevice(basicInfo);
+			});
 
-		deviceEmitter.on(DEVICE_DISCOVERY_EVENTS.DEVICE_LOST, (basicInfo: IAppetizeDeviceBasicInfo) => {
-			const device: Mobile.IDevice = this.$injector.resolve(AppetizeDevice, { basicInfo: basicInfo });
-			this.removeDevice(device.deviceInfo.identifier);
-		});
+			deviceEmitter.on(DEVICE_DISCOVERY_EVENTS.DEVICE_LOST, (basicInfo: IAppetizeDeviceBasicInfo) => {
+				const device: Mobile.IDevice = this.$injector.resolve(AppetizeDevice, { basicInfo: basicInfo });
+				this.removeDevice(device.deviceInfo.identifier);
+			});
+		}
 	}
 
 	public async checkForDevices(): Promise<void> { /* currently empty */ }

--- a/lib/mobile/mobile-core/appetize-device-discovery.ts
+++ b/lib/mobile/mobile-core/appetize-device-discovery.ts
@@ -2,7 +2,6 @@ import { EventEmitter } from "events";
 import { DEVICE_DISCOVERY_EVENTS } from "../../constants";
 import { deviceEmitter } from "cloud-device-emulator";
 import { AppetizeDevice } from "../device/appetize-device";
-import { values } from "lodash";
 
 export class AppetizeDeviceDiscovery extends EventEmitter implements Mobile.IDeviceDiscovery {
 	private devices: IDictionary<Mobile.IDevice> = {};
@@ -30,7 +29,7 @@ export class AppetizeDeviceDiscovery extends EventEmitter implements Mobile.IDev
 	public async startLookingForDevices(): Promise<void> {
 		if (!this._hasStartedLookingForDevices) {
 			this._hasStartedLookingForDevices = true;
-			values(deviceEmitter.getCurrentlyAttachedDevices()).forEach(basicInfo => {
+			_.values(deviceEmitter.getCurrentlyAttachedDevices()).forEach(basicInfo => {
 				this.addAppetizeDevice(basicInfo);
 			});
 
@@ -39,8 +38,7 @@ export class AppetizeDeviceDiscovery extends EventEmitter implements Mobile.IDev
 			});
 
 			deviceEmitter.on(DEVICE_DISCOVERY_EVENTS.DEVICE_LOST, (basicInfo: IAppetizeDeviceBasicInfo) => {
-				const device: Mobile.IDevice = this.$injector.resolve(AppetizeDevice, { basicInfo: basicInfo });
-				this.removeDevice(device.deviceInfo.identifier);
+				this.removeDevice(basicInfo.identifier);
 			});
 		}
 	}

--- a/lib/services/appetize-emulator-launcher.ts
+++ b/lib/services/appetize-emulator-launcher.ts
@@ -1,0 +1,11 @@
+export class AppetizeEmulatorLauncher implements IAppetizeEmulatorLauncher {
+
+	constructor(private $cloudEmulatorService: ICloudEmulatorService) { }
+
+	public async startEmulator(data: IAppetizeEmulatorStartData): Promise<string> {
+		const response: ICloudEmulatorResponse = await this.$cloudEmulatorService.deployApp(data.packageFile, data.platform);
+		return this.$cloudEmulatorService.startEmulator(response.publicKey, data.platform, data.model);
+	}
+}
+
+$injector.register("appetizeEmulatorLauncher", AppetizeEmulatorLauncher);

--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -9,10 +9,6 @@ import { EventEmitter } from "events";
 import * as constants from "../constants";
 const plist = require("simple-plist");
 
-interface IAmazonStorageEntryData extends IAmazonStorageEntry {
-	fileNameInS3: string;
-}
-
 export class CloudBuildService extends EventEmitter implements ICloudBuildService {
 	private static BUILD_STATUS_CHECK_INTERVAL = 1500;
 	private static BUILD_COMPLETE_STATUS = "Success";

--- a/lib/services/cloud-services/cloud-emulator-service.ts
+++ b/lib/services/cloud-services/cloud-emulator-service.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
 
 import { getSeverAddress, refresh } from "cloud-device-emulator";
-import { EMULATORS_SERVICE_NAME } from "../../constants";
+import { EMULATORS_SERVICE_NAME, HTTP_METHODS } from "../../constants";
 import { CloudServiceBase } from "./cloud-service-base";
 
 export class CloudEmulatorService extends CloudServiceBase implements ICloudEmulatorService {
@@ -21,31 +21,31 @@ export class CloudEmulatorService extends CloudServiceBase implements ICloudEmul
 		return `http://${serverInfo.host}:${serverInfo.port}?publicKey=${publicKey}&device=${deviceType}`;
 	}
 
-	public async deployApp(url: string, platform: string): Promise<ICloudEmulatorResponse> {
-		if (this.$fs.exists(path.resolve(url))) {
-			url = await this.$uploadService.updloadToS3(url);
+	public async deployApp(fileLocation: string, platform: string): Promise<ICloudEmulatorResponse> {
+		if (this.$fs.exists(path.resolve(fileLocation))) {
+			fileLocation = await this.$uploadService.updloadToS3(fileLocation);
 		}
 
 		const appetizeKeys = this.getEmulatorCredentials(platform);
 		if (!appetizeKeys) {
-			return this.createApp(url, platform);
+			return this.createApp(fileLocation, platform);
 		}
 
-		return this.updateApp(url, platform, appetizeKeys.publicKey, appetizeKeys.privateKey);
-	}
-
-	public async createApp(url: string, platform: string): Promise<ICloudEmulatorResponse> {
-		const response = await this.sendRequest<ICloudEmulatorResponse>("POST", "api/apps", { url, platform });
-		this.setEmulatorCredentials(response.publicKey, response.privateKey, response.platform);
-		return response;
-	}
-
-	public updateApp(url: string, platform: string, publicKey: string, privateKey: string): Promise<ICloudEmulatorResponse> {
-		return this.sendRequest<ICloudEmulatorResponse>("PUT", `api/apps/${publicKey}`, { url, platform });
+		return this.updateApp(fileLocation, platform, appetizeKeys.publicKey, appetizeKeys.privateKey);
 	}
 
 	public refereshEmulator(deviceIdentifier: string): Promise<void> {
 		return refresh(deviceIdentifier);
+	}
+
+	private async createApp(url: string, platform: string): Promise<ICloudEmulatorResponse> {
+		const response = await this.sendRequest<ICloudEmulatorResponse>(HTTP_METHODS.POST, "api/apps", { url, platform });
+		this.setEmulatorCredentials(response.publicKey, response.privateKey, response.platform);
+		return response;
+	}
+
+	private updateApp(url: string, platform: string, publicKey: string, privateKey: string): Promise<ICloudEmulatorResponse> {
+		return this.sendRequest<ICloudEmulatorResponse>(HTTP_METHODS.PUT, `api/apps/${publicKey}`, { url, platform });
 	}
 
 	private setEmulatorCredentials(publicKey: string, privateKey: string, platform: string): void {
@@ -59,7 +59,7 @@ export class CloudEmulatorService extends CloudServiceBase implements ICloudEmul
 		return <ICloudEmulatorKeys>this.loadCredentials()[platform];
 	}
 
-	private loadCredentials(): any {
+	private loadCredentials(): IEmulatorCredentials {
 		const configFileName = this.getCredentialsPath();
 		return this.$fs.exists(configFileName) ? this.$fs.readJson(configFileName) : {};
 	}

--- a/lib/services/cloud-services/cloud-emulator-service.ts
+++ b/lib/services/cloud-services/cloud-emulator-service.ts
@@ -56,7 +56,7 @@ export class CloudEmulatorService extends CloudServiceBase implements ICloudEmul
 	}
 
 	private getEmulatorCredentials(platform: string): ICloudEmulatorKeys {
-		return <ICloudEmulatorKeys>this.loadCredentials()[platform];
+		return this.loadCredentials()[platform];
 	}
 
 	private loadCredentials(): IEmulatorCredentials {

--- a/lib/services/cloud-services/cloud-emulator-service.ts
+++ b/lib/services/cloud-services/cloud-emulator-service.ts
@@ -1,6 +1,5 @@
 import * as path from "path";
 
-import { getSeverAddress, refresh } from "cloud-device-emulator";
 import { EMULATORS_SERVICE_NAME, HTTP_METHODS } from "../../constants";
 import { CloudServiceBase } from "./cloud-service-base";
 
@@ -8,7 +7,8 @@ export class CloudEmulatorService extends CloudServiceBase implements ICloudEmul
 
 	protected serviceName = EMULATORS_SERVICE_NAME;
 
-	constructor(protected $cloudRequestService: ICloudRequestService,
+	constructor(private $cloudDeviceEmulator: ICloudDeviceEmulator,
+		protected $cloudRequestService: ICloudRequestService,
 		private $uploadService: IUploadService,
 		private $fs: IFileSystem,
 		protected $options: IProfileDir) {
@@ -17,7 +17,7 @@ export class CloudEmulatorService extends CloudServiceBase implements ICloudEmul
 	}
 
 	public async startEmulator(publicKey: string, platform: string, deviceType: string): Promise<string> {
-		const serverInfo = await getSeverAddress();
+		const serverInfo = await this.$cloudDeviceEmulator.getSeverAddress();
 		return `http://${serverInfo.host}:${serverInfo.port}?publicKey=${publicKey}&device=${deviceType}`;
 	}
 
@@ -35,7 +35,7 @@ export class CloudEmulatorService extends CloudServiceBase implements ICloudEmul
 	}
 
 	public refereshEmulator(deviceIdentifier: string): Promise<void> {
-		return refresh(deviceIdentifier);
+		return this.$cloudDeviceEmulator.refresh(deviceIdentifier);
 	}
 
 	private async createApp(url: string, platform: string): Promise<ICloudEmulatorResponse> {

--- a/lib/services/cloud-services/cloud-emulator-service.ts
+++ b/lib/services/cloud-services/cloud-emulator-service.ts
@@ -1,0 +1,72 @@
+import * as path from "path";
+
+import { getSeverAddress, refresh } from "cloud-device-emulator";
+import { EMULATORS_SERVICE_NAME } from "../../constants";
+import { CloudServiceBase } from "./cloud-service-base";
+
+export class CloudEmulatorService extends CloudServiceBase implements ICloudEmulatorService {
+
+	protected serviceName = EMULATORS_SERVICE_NAME;
+
+	constructor(protected $cloudRequestService: ICloudRequestService,
+		private $uploadService: IUploadService,
+		private $fs: IFileSystem,
+		protected $options: IProfileDir) {
+
+		super($cloudRequestService);
+	}
+
+	public async startEmulator(publicKey: string, platform: string, deviceType: string): Promise<string> {
+		const serverInfo = await getSeverAddress();
+		return `http://${serverInfo.host}:${serverInfo.port}?publicKey=${publicKey}&device=${deviceType}`;
+	}
+
+	public async deployApp(url: string, platform: string): Promise<ICloudEmulatorResponse> {
+		if (this.$fs.exists(path.resolve(url))) {
+			url = await this.$uploadService.updloadToS3(url);
+		}
+
+		const appetizeKeys = this.getEmulatorCredentials(platform);
+		if (!appetizeKeys) {
+			return this.createApp(url, platform);
+		}
+
+		return this.updateApp(url, platform, appetizeKeys.publicKey, appetizeKeys.privateKey);
+	}
+
+	public async createApp(url: string, platform: string): Promise<ICloudEmulatorResponse> {
+		const response = await this.sendRequest<ICloudEmulatorResponse>("POST", "api/apps", { url, platform });
+		this.setEmulatorCredentials(response.publicKey, response.privateKey, response.platform);
+		return response;
+	}
+
+	public updateApp(url: string, platform: string, publicKey: string, privateKey: string): Promise<ICloudEmulatorResponse> {
+		return this.sendRequest<ICloudEmulatorResponse>("PUT", `api/apps/${publicKey}`, { url, platform });
+	}
+
+	public refereshEmulator(deviceIdentifier: string): Promise<void> {
+		return refresh(deviceIdentifier);
+	}
+
+	private setEmulatorCredentials(publicKey: string, privateKey: string, platform: string): void {
+		const configPath = this.getCredentialsPath();
+		let emulatorCredential = this.loadCredentials();
+		emulatorCredential[platform] = { publicKey, privateKey };
+		this.$fs.writeJson(configPath, emulatorCredential);
+	}
+
+	private getEmulatorCredentials(platform: string): ICloudEmulatorKeys {
+		return <ICloudEmulatorKeys>this.loadCredentials()[platform];
+	}
+
+	private loadCredentials(): any {
+		const configFileName = this.getCredentialsPath();
+		return this.$fs.exists(configFileName) ? this.$fs.readJson(configFileName) : {};
+	}
+
+	private getCredentialsPath(): string {
+		return path.join(this.$options.profileDir, "cloud-emulator.json");
+	}
+}
+
+$injector.register("cloudEmulatorService", CloudEmulatorService);

--- a/lib/services/cloud-services/upload-service.ts
+++ b/lib/services/cloud-services/upload-service.ts
@@ -1,0 +1,40 @@
+import * as uuid from "uuid";
+
+import { BUILD_SERVICE_NAME } from "../../constants";
+import { CloudServiceBase } from "./cloud-service-base";
+
+export class UploadService extends CloudServiceBase implements IUploadService {
+
+	protected serviceName = BUILD_SERVICE_NAME;
+
+	constructor(protected $cloudRequestService: ICloudRequestService,
+		private $httpClient: Server.IHttpClient,
+		private $errors: IErrors,
+		private $fs: IFileSystem) {
+		super($cloudRequestService);
+	}
+
+	public async updloadToS3(localFilePath: string): Promise<string> {
+		const fileNameInS3 = uuid.v4();
+		const preSignedUrlData = await this.sendRequest<IPresignURLResponse>("GET", `api/get-upload-url?filename=${fileNameInS3}`, {});
+		const requestOpts: any = {
+			url: preSignedUrlData.uploadPreSignedUrl,
+			method: "PUT"
+		};
+
+		requestOpts.body = this.$fs.readFile(localFilePath);
+		requestOpts.headers = requestOpts.headers || {};
+		// It is vital we set this, else the http request comes out as chunked and S3 doesn't support chunked requests
+		requestOpts.headers["Content-Length"] = requestOpts.body.length;
+
+		try {
+			await this.$httpClient.httpRequest(requestOpts);
+		} catch (err) {
+			this.$errors.failWithoutHelp(`Error while uploading ${localFilePath} to S3. Errors is:`, err.message);
+		}
+
+		return preSignedUrlData.publicDownloadUrl;
+	}
+}
+
+$injector.register("uploadService", UploadService);

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typescript": "2.1.5"
   },
   "dependencies": {
-    "cloud-device-emulator": "0.1.0",
+    "cloud-device-emulator": "~0.1.0",
     "cookie": "0.3.1",
     "lodash": "4.17.4",
     "minimatch": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "typescript": "2.1.5"
   },
   "dependencies": {
+    "cloud-device-emulator": "0.1.0",
     "cookie": "0.3.1",
     "lodash": "4.17.4",
     "minimatch": "3.0.4",

--- a/test/mobile/mobile-core/appetize-device-discovery.ts
+++ b/test/mobile/mobile-core/appetize-device-discovery.ts
@@ -1,0 +1,126 @@
+import { AppetizeDeviceDiscovery } from "../../../lib/mobile/mobile-core/appetize-device-discovery";
+import { DEVICE_DISCOVERY_EVENTS } from "../../../lib/constants";
+import { EventEmitter } from "events";
+import { Yok } from "mobile-cli-lib/yok";
+import { assert } from "chai";
+
+class CustomDeviceEmitter extends EventEmitter implements CloudDeviceEmitter {
+	private _initialDevices: IAttachedDevices;
+
+	constructor(initialDevices?: IAttachedDevices) {
+		super();
+		this._initialDevices = initialDevices || {};
+	}
+	public getCurrentlyAttachedDevices(): IAttachedDevices {
+		return this._initialDevices;
+	}
+}
+
+describe("appetize device discovery", () => {
+	describe("startLookingForDevices", async () => {
+		const customDevice = {
+			identifier: "id",
+			publicKey: "publicKey",
+			model: "model",
+			os: "os"
+		};
+
+		const initialDevices: IAttachedDevices = {
+			id: customDevice
+		};
+
+		function createTestInjector(devices?: IAttachedDevices): IInjector {
+			const customEventEmitter = new CustomDeviceEmitter(devices);
+			const testInjector = new Yok();
+			testInjector.register("injector", testInjector);
+			testInjector.register("cloudDeviceEmulator", {
+				get deviceEmitter() {
+					return customEventEmitter;
+				}
+			});
+			testInjector.register("cloudEmulatorService", { /* empty */ });
+			testInjector.register("mobileHelper", {
+				normalizePlatformName: (platform: string) => platform.toLowerCase()
+			});
+
+			return testInjector;
+		}
+
+		it(`should attach ${DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND}/${DEVICE_DISCOVERY_EVENTS.DEVICE_LOST}`, async () => {
+			const injector = createTestInjector();
+
+			const appetizeDeviceDiscovery: Mobile.IDeviceDiscovery = injector.resolve(AppetizeDeviceDiscovery);
+			await appetizeDeviceDiscovery.startLookingForDevices();
+
+			const deviceEmitter = injector.resolve("cloudDeviceEmulator").deviceEmitter;
+
+			assert.deepEqual(deviceEmitter.listenerCount(DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND), 1);
+			assert.deepEqual(deviceEmitter.listenerCount(DEVICE_DISCOVERY_EVENTS.DEVICE_LOST), 1);
+		});
+
+		it(`should not attach ${DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND}/${DEVICE_DISCOVERY_EVENTS.DEVICE_LOST} multiple times upon multiple calls`, async () => {
+			const injector = createTestInjector();
+
+			const appetizeDeviceDiscovery: Mobile.IDeviceDiscovery = injector.resolve(AppetizeDeviceDiscovery);
+			await appetizeDeviceDiscovery.startLookingForDevices();
+			await appetizeDeviceDiscovery.startLookingForDevices();
+
+			const deviceEmitter = injector.resolve("cloudDeviceEmulator").deviceEmitter;
+
+			assert.deepEqual(deviceEmitter.listenerCount(DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND), 1);
+			assert.deepEqual(deviceEmitter.listenerCount(DEVICE_DISCOVERY_EVENTS.DEVICE_LOST), 1);
+		});
+
+		it("should detect already running devices", async () => {
+			const injector = createTestInjector(initialDevices);
+			let hasDetectedDevice = false;
+
+			const appetizeDeviceDiscovery: Mobile.IDeviceDiscovery = injector.resolve(AppetizeDeviceDiscovery);
+			appetizeDeviceDiscovery.on(DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND, (device: Mobile.IDevice) => {
+				hasDetectedDevice = true;
+				assert.deepEqual(device.deviceInfo.identifier, customDevice.identifier);
+				assert.deepEqual(device.deviceInfo.model, customDevice.model);
+			});
+
+			await appetizeDeviceDiscovery.startLookingForDevices();
+			assert.isTrue(hasDetectedDevice);
+		});
+
+		it(`should detect devices on ${DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND}`, async () => {
+			const injector = createTestInjector();
+			let hasDetectedDevice = false;
+
+			const deviceEmitter: EventEmitter = injector.resolve("cloudDeviceEmulator").deviceEmitter;
+
+			const appetizeDeviceDiscovery: Mobile.IDeviceDiscovery = injector.resolve(AppetizeDeviceDiscovery);
+			appetizeDeviceDiscovery.on(DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND, (device: Mobile.IDevice) => {
+				hasDetectedDevice = true;
+				assert.deepEqual(device.deviceInfo.identifier, customDevice.identifier);
+				assert.deepEqual(device.deviceInfo.model, customDevice.model);
+			});
+
+			await appetizeDeviceDiscovery.startLookingForDevices();
+			deviceEmitter.emit(DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND, customDevice);
+			assert.isTrue(hasDetectedDevice);
+		});
+
+		it(`should lose devices on ${DEVICE_DISCOVERY_EVENTS.DEVICE_LOST}`, async () => {
+			const injector = createTestInjector(initialDevices);
+			let hasLostDevice = false;
+
+			const deviceEmitter: EventEmitter = injector.resolve("cloudDeviceEmulator").deviceEmitter;
+
+			const appetizeDeviceDiscovery: Mobile.IDeviceDiscovery = injector.resolve(AppetizeDeviceDiscovery);
+			appetizeDeviceDiscovery.on(DEVICE_DISCOVERY_EVENTS.DEVICE_LOST, (device: Mobile.IDevice) => {
+				hasLostDevice = true;
+				assert.deepEqual(device.deviceInfo.identifier, customDevice.identifier);
+				assert.deepEqual(device.deviceInfo.model, customDevice.model);
+			});
+
+			await appetizeDeviceDiscovery.startLookingForDevices();
+			deviceEmitter.emit(DEVICE_DISCOVERY_EVENTS.DEVICE_LOST, customDevice);
+
+			assert.isTrue(hasLostDevice);
+		});
+	});
+});

--- a/test/services/cloud-emulator-service.ts
+++ b/test/services/cloud-emulator-service.ts
@@ -1,0 +1,82 @@
+import { CloudEmulatorService } from "../../lib/services/cloud-services/cloud-emulator-service";
+import { HTTP_METHODS } from "../../lib/constants";
+import { Yok } from "mobile-cli-lib/yok";
+import { assert } from "chai";
+
+describe("cloud emulator service", () => {
+	describe("deployApp", async () => {
+		const emulatorCredentials = { publicKey: "publicKey", privateKey: "privateKey", platform: "platform" };
+		const filePath = "localPath";
+		const platform = "platform";
+
+		function createTestInjector(): IInjector {
+			const testInjector = new Yok();
+			testInjector.register("cloudRequestService", {
+				call: async () => emulatorCredentials
+			});
+			testInjector.register("fs", {
+				exists: () => true,
+				readJson: () => ({}),
+				writeJson: () => { /* empty */ }
+			});
+			testInjector.register("uploadService", {
+				updloadToS3: async (url: string) => url
+			});
+			testInjector.register("options", {
+				profileDir: "test"
+			});
+
+			return testInjector;
+		}
+
+		it("should upload to S3 in case a local file is passed", async () => {
+			const injector = createTestInjector();
+			let hasUploadedToS3 = false;
+			injector.resolve("uploadService").updloadToS3 = (url: string) => {
+				if (url === filePath) {
+					hasUploadedToS3 = true;
+				}
+			};
+
+			const cloudEmulatorService: ICloudEmulatorService = injector.resolve(CloudEmulatorService);
+			await cloudEmulatorService.deployApp(filePath, platform);
+
+			assert.isTrue(hasUploadedToS3);
+		});
+
+		it("should call create if emulator credentials not present", async () => {
+			const injector = createTestInjector();
+			let hasCalledCloudRequestService = false;
+			injector.resolve("cloudRequestService").call = (options: ICloudRequestOptions) => {
+				hasCalledCloudRequestService = true;
+				assert.deepEqual(options.method, HTTP_METHODS.POST, "create is not called upon missing credentials");
+
+				return emulatorCredentials;
+			};
+
+			const cloudEmulatorService: ICloudEmulatorService = injector.resolve(CloudEmulatorService);
+			await cloudEmulatorService.deployApp(filePath, platform);
+
+			assert.isTrue(hasCalledCloudRequestService);
+		});
+
+		it("should call update if emulator credentials present", async () => {
+			const injector = createTestInjector();
+			let hasCalledCloudRequestService = false;
+			injector.resolve("fs").readJson = () => ({
+				[platform]: emulatorCredentials
+			});
+			injector.resolve("cloudRequestService").call = (options: ICloudRequestOptions) => {
+				hasCalledCloudRequestService = true;
+				assert.deepEqual(options.method, HTTP_METHODS.PUT, "update is not called upon existing credentials");
+
+				return emulatorCredentials;
+			};
+
+			const cloudEmulatorService: ICloudEmulatorService = injector.resolve(CloudEmulatorService);
+			await cloudEmulatorService.deployApp(filePath, platform);
+
+			assert.isTrue(hasCalledCloudRequestService);
+		});
+	});
+});

--- a/test/services/cloud-emulator-service.ts
+++ b/test/services/cloud-emulator-service.ts
@@ -22,6 +22,7 @@ describe("cloud emulator service", () => {
 			testInjector.register("uploadService", {
 				updloadToS3: async (url: string) => url
 			});
+			testInjector.register("cloudDeviceEmulator", { /* empty */ });
 			testInjector.register("options", {
 				profileDir: "test"
 			});


### PR DESCRIPTION
* Subscribe `appetizeDeviceDiscovery` to `$devicesService` and raise `deviceFound` and `deviceLost` events accordingly.
* Implement all the classes around `appetize-device` like `appetize-application-manager` and `appetize-device-file-system`
* Introduce public class `appetizeEmulatorLauncher` with method `startEmulator` that can start up emulators
* Implement `installApplication` in `appetize-application-manager` which enables `tns deploy` to work accordingly
* Restart the emulator upon reinstalling an app

Ping @rosen-vladimirov @TsvetanMilanov 

Merge after https://github.com/telerik/mobile-cli-lib/pull/963 and https://github.com/telerik/cloud-device-emulator/pull/4