### PR TITLE
Fix getting version for runtime and CLI

### DIFF
--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -13,6 +13,7 @@ interface IAmazonStorageEntryData extends CloudService.AmazonStorageEntry {
 }
 
 export class CloudBuildService implements ICloudBuildService {
+	private static DEFAULT_VERSION = "3.0.0";
 
 	constructor(private $fs: IFileSystem,
 		private $itmsServicesPlistHelper: IItmsServicesPlistHelper,
@@ -164,7 +165,7 @@ export class CloudBuildService implements ICloudBuildService {
 		// HACK just for this version. After that we'll have UI for getting runtime version.
 		// Until then, use the coreModulesVersion.
 		const coreModulesVersion = this.$fs.readJson(path.join(projectSettings.projectDir, "package.json")).dependencies["tns-core-modules"];
-		const runtimeVersion = this.getRuntimeVersion(platform, projectSettings.nativescriptData, coreModulesVersion);
+		const runtimeVersion = await this.getRuntimeVersion(platform, projectSettings.nativescriptData, coreModulesVersion);
 		const cliVersion = await this.getCliVersion(runtimeVersion);
 		const sanitizedProjectName = this.$projectHelper.sanitizeName(projectSettings.projectName);
 
@@ -376,24 +377,49 @@ export class CloudBuildService implements ICloudBuildService {
 		return fullPath.substring(projectDir.length);
 	}
 
-	private getRuntimeVersion(platform: string, nativescriptData: any, coreModulesVersion: string): string {
+	private async getRuntimeVersion(platform: string, nativescriptData: any, coreModulesVersion: string): Promise<string> {
 		const runtimePackageName = `tns-${platform.toLowerCase()}`;
 		let runtimeVersion = nativescriptData && nativescriptData[runtimePackageName] && nativescriptData[runtimePackageName].version;
-		if (!runtimeVersion && coreModulesVersion && semver.valid(coreModulesVersion)) {
+		if (!runtimeVersion && coreModulesVersion) {
 			// no runtime added. Let's find out which one we need based on the tns-core-modules.
-			runtimeVersion = `${semver.major(coreModulesVersion)}.${semver.minor(coreModulesVersion)}.*`;
+			if (semver.valid(coreModulesVersion)) {
+				runtimeVersion = `${semver.major(coreModulesVersion)}.${semver.minor(coreModulesVersion)}.*`;
+			} else if (semver.validRange(coreModulesVersion)) {
+				// In case tns-core-modules in package.json are referred as `~x.x.x` - this is not a valid version, but is valid range.
+				runtimeVersion = await this.getLatestMatchingVersion(runtimePackageName, coreModulesVersion);
+			}
 		}
 
-		return runtimeVersion || "2.5.0";
+		return runtimeVersion || CloudBuildService.DEFAULT_VERSION;
 	}
 
 	private async getCliVersion(runtimeVersion: string): Promise<string> {
 		try {
-			const response = await this.$httpClient.httpRequest("http://registry.npmjs.org/nativescript");
-			const versions = _.keys(JSON.parse(response.body).versions);
-			return "2.5.0" || semver.maxSatisfying(versions, `~${runtimeVersion}`);
+			const latestMatchingVersion = await this.getLatestMatchingVersion("nativescript", `~${runtimeVersion}`);
+			return latestMatchingVersion || CloudBuildService.DEFAULT_VERSION;
 		} catch (err) {
+			this.$logger.trace(`Unable to get information about CLI versions. Error is: ${err.message}`);
 			return `${semver.major(runtimeVersion)}.${semver.minor(runtimeVersion)}.0`;
+		}
+	}
+
+	private async getLatestMatchingVersion(packageName: string, range: string): Promise<string> {
+		const versions = await this.getVersionsFromNpm(packageName);
+		if (versions.length) {
+			return semver.maxSatisfying(versions, range);
+		}
+
+		return null;
+	}
+
+	private async getVersionsFromNpm(packageName: string): Promise<string[]> {
+		try {
+			const response = await this.$httpClient.httpRequest(`http://registry.npmjs.org/${packageName}`);
+			const versions = _.keys(JSON.parse(response.body).versions);
+			return versions;
+		} catch (err) {
+			this.$logger.trace(`Unable to get versions of ${packageName} from npm. Error is: ${err.message}.`);
+			return [];
 		}
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {


### PR DESCRIPTION
Fix getting the version of CLI and runtime when building in the cloud. Make sure we respect tns-core-modules version from package.json even if it is written as range ("~x.x.x") and use the range for getting correct versions.