### PR TITLE
Improve authentication service.

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,32 @@ tns.authenticationService.refreshCurrentUserToken()
 	.catch(err => console.error(err));
 ```
 
+* `cancelLogin` - Stops the current login process and rejects the login promise with an error.
+</br>
+
+Definition:
+
+```TypeScript
+/**
+ * Stops the current login process and rejects the login promise with an error.
+ * @returns {void}
+ */
+cancelLogin(): void;
+```
+</br>
+
+Usage:
+```JavaScript
+const tns = require("nativescript");
+
+tns.authenticationService
+	.login()
+	.then(userInfo => console.log(userInfo))
+	.catch(err => console.error(err));
+
+tns.authenticationService.cancelLogin();
+```
+
 #### Interfaces:
 ```TypeScript
 interface IUser {
@@ -307,6 +333,12 @@ interface IAuthenticationService {
 	 * @returns {Promise<ITokenState>} Returns the token state
 	 */
 	getCurrentUserTokenState(): Promise<ITokenState>;
+
+	/**
+	 * Stops the current login process and rejects the login promise with an error.
+	 * @returns {void}
+	 */
+	cancelLogin(): void;
 }
 
 interface ILoginOptions {

--- a/README.md
+++ b/README.md
@@ -206,9 +206,11 @@ Definition:
 ```TypeScript
 /**
  * Invalidates the current user authentication data.
+ * If options.openAction is provided, it will be used to open the logout url instead of the default opener.
+ * @param {IOpenActionOptions} options Optional settings for the logout method.
  * @returns {void}
  */
-logout(): void;
+logout(options?: IOpenActionOptions): void;
 ```
 </br>
 Usage:
@@ -217,6 +219,20 @@ Usage:
 const tns = require("nativescript");
 
 tns.authenticationService.logout();
+```
+
+```JavaScript
+const tns = require("nativescript");
+const childProcess = require("child_process");
+
+const openAction = url => {
+	const isWin = /^win/.test(process.platform);
+	const openCommand = isWin ? "start" : "open";
+	childProcess.execSync(`${openCommand} ${url}`);
+};
+const logoutOptions = { openAction: openAction };
+
+tns.authenticationService.logout(logoutOptions);
 ```
 
 * `isUserLoggedIn` - Checks if the access token of the current user is valid. If it is - the method will return true. If it isn't - the method will try to issue new access token. If the method can't issue new token it will return false.
@@ -319,9 +335,11 @@ interface IAuthenticationService {
 
 	/**
 	 * Invalidates the current user authentication data.
+	 * If options.openAction is provided, it will be used to open the logout url instead of the default opener.
+	 * @param {ILoginOptions} options Optional settings for the logout method.
 	 * @returns {void}
 	 */
-	logout(): void;
+	logout(options?: IOpenActionOptions): void;
 
 	/**
 	 * Uses the refresh token of the current user to issue new access token.
@@ -341,12 +359,14 @@ interface IAuthenticationService {
 	cancelLogin(): void;
 }
 
-interface ILoginOptions {
+interface IOpenActionOptions {
 	/**
-	 * Action which will be used to open the login url.
+	 * Action which will receive url and decide how to open it.
 	 */
-	openAction?: (loginUrl: string) => void;
+	openAction?: (url: string) => void;
+}
 
+interface ILoginOptions extends IOpenActionOptions {
 	/**
 	 * Sets the ammount of time which the login method will wait for login response in non-interactive terminal.
 	 */

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ interface IAuthenticationService {
 	/**
 	 * Invalidates the current user authentication data.
 	 * If options.openAction is provided, it will be used to open the logout url instead of the default opener.
-	 * @param {ILoginOptions} options Optional settings for the logout method.
+	 * @param {IOpenActionOptions} options Optional settings for the logout method.
 	 * @returns {void}
 	 */
 	logout(options?: IOpenActionOptions): void;

--- a/lib/definitions/authentication-service.d.ts
+++ b/lib/definitions/authentication-service.d.ts
@@ -17,9 +17,11 @@ interface IAuthenticationService {
 
 	/**
 	 * Invalidates the current user authentication data.
+	 * If options.openAction is provided, it will be used to open the logout url instead of the default opener.
+	 * @param {IOpenActionOptions} options Optional settings for the logout method.
 	 * @returns {void}
 	 */
-	logout(): void;
+	logout(options?: IOpenActionOptions): void;
 
 	/**
 	 * Uses the refresh token of the current user to issue new access token.
@@ -39,12 +41,14 @@ interface IAuthenticationService {
 	cancelLogin(): void;
 }
 
-interface ILoginOptions {
+interface IOpenActionOptions {
 	/**
-	 * Action which will be used to open the login url.
+	 * Action which will receive url and decide how to open it.
 	 */
-	openAction?: (loginUrl: string) => void;
+	openAction?: (url: string) => void;
+}
 
+interface ILoginOptions extends IOpenActionOptions {
 	/**
 	 * Sets the ammount of time which the login method will wait for login response in non-interactive terminal.
 	 */

--- a/lib/definitions/authentication-service.d.ts
+++ b/lib/definitions/authentication-service.d.ts
@@ -31,6 +31,12 @@ interface IAuthenticationService {
 	 * @returns {Promise<boolean>} Returns true if the user is logged in.
 	 */
 	isUserLoggedIn(): Promise<boolean>;
+
+	/**
+	 * Stops the current login process and rejects the login promise with an error.
+	 * @returns {void}
+	 */
+	cancelLogin(): void;
 }
 
 interface ILoginOptions {

--- a/lib/definitions/cloud-services/auth-cloud-service.d.ts
+++ b/lib/definitions/cloud-services/auth-cloud-service.d.ts
@@ -3,6 +3,7 @@ interface IAuthCloudService {
 	getLoginUrl(port: number): string;
 	refreshToken(refreshToken: string): Promise<ITokenData>;
 	getTokenState(token: string): Promise<ITokenState>;
+	getLogoutUrl(): string;
 }
 
 interface ITokenState {

--- a/lib/services/authentication-service.ts
+++ b/lib/services/authentication-service.ts
@@ -38,7 +38,7 @@ export class AuthenticationService implements IAuthenticationService {
 					const loginResponse = parsedUrl.query.response;
 					if (loginResponse) {
 						await this.serveLoginFile("end.html")(request, response);
-						this.localhostServer.close();
+						this.killLocalhostServer();
 
 						isResolved = true;
 
@@ -113,8 +113,7 @@ export class AuthenticationService implements IAuthenticationService {
 		this.$logger.trace("Cancel login.");
 		if (this.localhostServer) {
 			this.$logger.trace("Stopping localhost server.");
-			this.localhostServer.close();
-			this.localhostServer = null;
+			this.killLocalhostServer();
 		}
 
 		if (this.rejectLoginPromiseAction) {
@@ -128,7 +127,7 @@ export class AuthenticationService implements IAuthenticationService {
 		options = options || {};
 
 		const logoutUrl = this.$authCloudService.getLogoutUrl();
-		this.$logger.trace(`Logging out. Logotu url is: ${logoutUrl}`);
+		this.$logger.trace(`Logging out. Logout url is: ${logoutUrl}`);
 
 		if (options.openAction) {
 			options.openAction(logoutUrl);
@@ -175,6 +174,11 @@ export class AuthenticationService implements IAuthenticationService {
 
 	private serveLoginFile(relPath: string): (request: ServerRequest, response: ServerResponse) => Promise<void> {
 		return this.$httpServer.serveFile(join(__dirname, "..", "..", "resources", "login", relPath));
+	}
+
+	private killLocalhostServer(): void {
+		this.localhostServer.close();
+		this.localhostServer = null;
 	}
 }
 

--- a/lib/services/authentication-service.ts
+++ b/lib/services/authentication-service.ts
@@ -1,10 +1,12 @@
-import { ServerRequest, ServerResponse } from "http";
+import { ServerRequest, ServerResponse, Server } from "http";
 import { parse } from "url";
 import { join } from "path";
 import { isInteractive } from "../helpers";
 
 export class AuthenticationService implements IAuthenticationService {
 	private static DEFAULT_NONINTERACTIVE_LOGIN_TIMEOUT_MS: number = 15 * 60 * 1000;
+	private localhostServer: Server;
+	private rejectLoginPromiseAction: (data: any) => void;
 
 	constructor(private $authCloudService: IAuthCloudService,
 		private $fs: IFileSystem,
@@ -15,6 +17,11 @@ export class AuthenticationService implements IAuthenticationService {
 
 	public async login(options?: ILoginOptions): Promise<IUser> {
 		options = options || {};
+
+		if (this.localhostServer) {
+			this.cancelLogin();
+		}
+
 		// Start the localhost server to wait for the login response.
 		let timeoutID: NodeJS.Timer | number = undefined;
 		let authCompleteResolveAction: (value?: any | PromiseLike<any>) => void;
@@ -23,7 +30,7 @@ export class AuthenticationService implements IAuthenticationService {
 		this.$logger.info("Launching login page in browser.");
 
 		let loginUrl: string;
-		let localhostServer = this.$httpServer.createServer({
+		this.localhostServer = this.$httpServer.createServer({
 			routes: {
 				"/": async (request: ServerRequest, response: ServerResponse) => {
 					this.$logger.debug("Login complete: " + request.url);
@@ -31,11 +38,12 @@ export class AuthenticationService implements IAuthenticationService {
 					const loginResponse = parsedUrl.query.response;
 					if (loginResponse) {
 						await this.serveLoginFile("end.html")(request, response);
-						localhostServer.close();
+						this.localhostServer.close();
 
 						isResolved = true;
 
 						const decodedResponse = new Buffer(loginResponse, "base64").toString();
+						this.rejectLoginPromiseAction = null;
 						authCompleteResolveAction(decodedResponse);
 					} else {
 						this.$httpServer.redirect(response, loginUrl);
@@ -44,14 +52,15 @@ export class AuthenticationService implements IAuthenticationService {
 			}
 		});
 
-		localhostServer.listen(0);
+		this.localhostServer.listen(0);
 
-		await this.$fs.futureFromEvent(localhostServer, "listening");
+		await this.$fs.futureFromEvent(this.localhostServer, "listening");
 
 		const authComplete = new Promise<string>((resolve, reject) => {
 			authCompleteResolveAction = resolve;
+			this.rejectLoginPromiseAction = reject;
 
-			const port = localhostServer.address().port;
+			const port = this.localhostServer.address().port;
 
 			loginUrl = this.$authCloudService.getLoginUrl(port);
 
@@ -98,6 +107,21 @@ export class AuthenticationService implements IAuthenticationService {
 		this.$userService.setUserData(userData);
 
 		return userData.userInfo;
+	}
+
+	public cancelLogin(): void {
+		this.$logger.trace("Cancel login.");
+		if (this.localhostServer) {
+			this.$logger.trace("Stopping localhost server.");
+			this.localhostServer.close();
+			this.localhostServer = null;
+		}
+
+		if (this.rejectLoginPromiseAction) {
+			this.$logger.trace("Rejecting login promise.");
+			this.rejectLoginPromiseAction(new Error("Login canceled."));
+			this.rejectLoginPromiseAction = null;
+		}
 	}
 
 	public logout(): void {

--- a/lib/services/authentication-service.ts
+++ b/lib/services/authentication-service.ts
@@ -124,7 +124,18 @@ export class AuthenticationService implements IAuthenticationService {
 		}
 	}
 
-	public logout(): void {
+	public logout(options?: IOpenActionOptions): void {
+		options = options || {};
+
+		const logoutUrl = this.$authCloudService.getLogoutUrl();
+		this.$logger.trace(`Logging out. Logotu url is: ${logoutUrl}`);
+
+		if (options.openAction) {
+			options.openAction(logoutUrl);
+		} else {
+			this.$opener.open(logoutUrl);
+		}
+
 		this.$userService.clearUserData();
 	}
 

--- a/lib/services/cloud-services/auth-cloud-service.ts
+++ b/lib/services/cloud-services/auth-cloud-service.ts
@@ -9,10 +9,8 @@ export class AuthCloudService extends CloudServiceBase implements IAuthCloudServ
 	}
 
 	public getLoginUrl(port: number): string {
-		const proto = this.$cloudServicesProxy.getServiceProto(AUTH_SERVICE_NAME);
-		const host = this.$cloudServicesProxy.getServiceAddress(AUTH_SERVICE_NAME);
-		const urlPath = this.$cloudServicesProxy.getUrlPath(AUTH_SERVICE_NAME, "api/login");
-		return `${proto}://${host}${urlPath}?port=${port}`;
+		const loginUrl = this.getAuthUrl("api/login");
+		return `${loginUrl}?port=${port}`;
 	}
 
 	public refreshToken(refreshToken: string): Promise<ITokenData> {
@@ -25,6 +23,17 @@ export class AuthCloudService extends CloudServiceBase implements IAuthCloudServ
 
 	public getTokenState(token: string): Promise<ITokenState> {
 		return this.sendRequest<ITokenState>(HTTP_METHODS.POST, "api/token-state", { token });
+	}
+
+	public getLogoutUrl(): string {
+		return this.getAuthUrl("api/logout");
+	}
+
+	private getAuthUrl(urlPath: string): string {
+		const proto = this.$cloudServicesProxy.getServiceProto(AUTH_SERVICE_NAME);
+		const host = this.$cloudServicesProxy.getServiceAddress(AUTH_SERVICE_NAME);
+		const url = this.$cloudServicesProxy.getUrlPath(AUTH_SERVICE_NAME, urlPath);
+		return `${proto}://${host}${url}`;
 	}
 }
 


### PR DESCRIPTION
We should add `cancelLogin` method because when we use the `nativescript-cloud` as a module in long living process we want to have a way to stop the current login session.

When we login our identity services sets a cookie. If we don't clear this cookie after logout we will automatically login the user on the next login request. We don't want this behavior so we should add request to `logout` endpoint on our server to clear the cookie. Because of this change we have a breaking change in our logout api - the logout method accepts optional options object with open action. This open action will be used to open the logout url.