### PR TITLE
Implement clean build option

### DIFF
--- a/lib/commands/cloud-build.ts
+++ b/lib/commands/cloud-build.ts
@@ -26,7 +26,7 @@ export class CloudBuild implements ICommand {
 		}
 
 		const pathToProvision = this.$options.provision ? path.resolve(this.$options.provision) : "";
-		const projectSettings = { projectDir: this.$projectData.projectDir, projectId: this.$projectData.projectId, projectName: this.$projectData.projectName, nativescriptData };
+		const projectSettings = { projectDir: this.$projectData.projectDir, projectId: this.$projectData.projectId, projectName: this.$projectData.projectName, nativescriptData, clean: this.$options.clean };
 		const buildConfiguration = this.$options.release ? "Release" : "Debug";
 		await this.$cloudBuildService.build(projectSettings,
 			platform, buildConfiguration,

--- a/lib/definitions/cloud-build-service.d.ts
+++ b/lib/definitions/cloud-build-service.d.ts
@@ -126,6 +126,11 @@ interface IProjectSettings {
 	 * The value of `nativescript` key from project's package.json.
 	 */
 	nativescriptData: any;
+
+	/**
+	 *  Whether to clean & build. By default incremental build without clean is performed.
+	 */
+	clean: boolean;
 }
 
 /**

--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -236,7 +236,7 @@ export class CloudBuildService extends EventEmitter implements ICloudBuildServic
 		});
 	}
 
-	private async prepareBuildRequest(projectSettings: { projectDir: string, projectId: string, projectName: string, nativescriptData: any },
+	private async prepareBuildRequest(projectSettings: IProjectSettings,
 		platform: string, buildConfiguration: string): Promise<any> {
 
 		const projectZipFile = await this.zipProject(projectSettings.projectDir);
@@ -249,6 +249,11 @@ export class CloudBuildService extends EventEmitter implements ICloudBuildServic
 		const cliVersion = await this.getCliVersion(runtimeVersion);
 		const sanitizedProjectName = this.$projectHelper.sanitizeName(projectSettings.projectName);
 
+		/** Although the nativescript-cloud is an extension that is used only with nativescript projects,
+		 * current implementation of the builder daemon will not add default framework. This breaks tooling when incremental build is
+		 * performed. Passing the framework=tns here is more consistent that adding conditional
+		 * behavior in the tooling.
+		 */
 		return {
 			properties: {
 				buildConfiguration: buildConfiguration,
@@ -258,7 +263,9 @@ export class CloudBuildService extends EventEmitter implements ICloudBuildServic
 				runtimeVersion: runtimeVersion,
 				sessionKey: buildPreSignedUrlData.sessionKey,
 				templateAppName: sanitizedProjectName,
-				projectName: sanitizedProjectName
+				projectName: sanitizedProjectName,
+				framework: "tns",
+				useIncrementalBuild: !projectSettings.clean
 			},
 			buildFiles: [
 				{


### PR DESCRIPTION
* To trigger an incremental, build the build request data JSON
  must set the property useIncrementalBuild to "true". This is the default
  behavior. Using the --clean option will explicitly require
  clean & full build.
* Although the nativescript-cloud is an extension that is used only with
  nativescript projects, current implementation of the builder daemon will
  not add default framework. This breaks tooling when incremental build is
  performed. Passing the framework here is more consistent that adding conditional
  behavior in the tooling.

http://teampulse.telerik.com/view#item/319525