### PR TITLE
Fix undefined error

### DIFF
--- a/lib/services/authentication-service.ts
+++ b/lib/services/authentication-service.ts
@@ -81,7 +81,7 @@ export class AuthenticationService implements IAuthenticationService {
 					timeoutID = setTimeout(() => {
 						if (!isResolved) {
 							this.$logger.debug("Aborting login procedure due to inactivity.");
-							reject("Aborting login procedure due to inactivity.");
+							reject(new Error("Aborting login procedure due to inactivity."));
 						}
 					}, timeout);
 				}

--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -193,7 +193,7 @@ export class CloudBuildService extends EventEmitter implements ICloudBuildServic
 				} else if (!buildStatus) {
 					// We will get here if there is no build status twice in a row.
 					clearInterval(buildIntervalId);
-					return reject("Failed to start cloud build.");
+					return reject(new Error("Failed to start cloud build."));
 				}
 
 				if (!buildStatus) {
@@ -212,7 +212,7 @@ export class CloudBuildService extends EventEmitter implements ICloudBuildServic
 
 				if (buildStatus.status === CloudBuildService.BUILD_FAILED_STATUS) {
 					clearInterval(buildIntervalId);
-					return reject("Build failed.");
+					return reject(new Error("Build failed."));
 				}
 
 				if (buildStatus.status === CloudBuildService.BUILD_IN_PROGRESS_STATUS) {


### PR DESCRIPTION
Whenever rejecting a promise an error object needs to be passed. Otherwise CLI fails to display the error message, because it tries to [meddle with the error's stack](https://github.com/telerik/mobile-cli-lib/blob/master/errors.ts#L13)

Fixes `undefined` error message

Ping @rosen-vladimirov @TsvetanMilanov @nadyaA 