### PR TITLE
Implement getCloudBuildOutputDirectory method

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,31 @@ tns.cloudBuildService
 	.catch(err => console.error("Data is invalid:", err));
 ```
 
+* `getBuildOutputDirectory` - Returns the path to the directory where the build output may be found.
+</br>
+Definition:
+
+```TypeScript
+/**
+ * Returns the path to the directory where the build output may be found.
+ * @param {ICloudBuildOutputDirectoryOptions} options Options that are used to determine the build output directory.
+ * @returns {string} The build output directory.
+ */
+getBuildOutputDirectory(options: ICloudBuildOutputDirectoryOptions): string;
+```
+Detailed description of the parameter can be found [here](./lib/definitions/cloud-build-service.d.ts).
+</br>
+Usage:
+```JavaScript
+const tns = require("nativescript");
+const cloudBuildOutputDirectory = tns.cloudBuildService
+									.getBuildOutputDirectory({
+										platform: "ios",
+										projectDir: "/tmp/myProject"
+										emulator: false
+									});
+```
+
 ### Module appetizeEmulatorLauncher
 The `appetizeEmulatorLauncher` provides a way for initial interaction with appetize emulators. You can call the following methods:
 * `startEmulator` method - starts an appetize emulator and returns a url where an html page is located, containing an iframe with the actual emulator. </br>

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -32,6 +32,11 @@ export const DEVICE_DISCOVERY_EVENTS = {
 	DEVICE_LOST: "deviceLost"
 };
 
+export const CLOUD_BUILD_DIRECTORY_NAMES = {
+	DEVICE: "device",
+	EMULATOR: "emulator"
+};
+
 export const DEVICE_INFO = {
 	TYPE: "Emulator",
 	STATUS: "Connected",

--- a/lib/definitions/cloud-build-service.d.ts
+++ b/lib/definitions/cloud-build-service.d.ts
@@ -76,6 +76,13 @@ interface ICloudBuildService {
 		projectId: string,
 		androidBuildData?: IAndroidBuildData,
 		iOSBuildData?: IIOSBuildData): Promise<void>;
+
+	/**
+	 * Returns the path to the directory where the build output may be found.
+	 * @param {ICloudBuildOutputDirectoryOptions} options Options that are used to determine the build output directory.
+	 * @returns {string} The build output directory.
+	 */
+	getBuildOutputDirectory(options: ICloudBuildOutputDirectoryOptions): string;
 }
 
 /**
@@ -183,6 +190,26 @@ interface IBuildStatus {
 	 * The build status.
 	 */
 	status: string;
+}
+
+/**
+ * Describes options that can be passed in order to specify the exact location of the built package.
+ */
+interface ICloudBuildOutputDirectoryOptions {
+	/**
+	 * Android or iOS
+	 */
+	platform: string;
+
+	/**
+	 * Directory where the project is located.
+	 */
+	projectDir: string;
+
+	/**
+	 * Whether the build is for emulator or not.
+	 */
+	emulator?: boolean;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {


### PR DESCRIPTION
Used to get the path to the directory where the build output may be found.

Ping @nadyaA @rosen-vladimirov @TsvetanMilanov 