### PR TITLE
Dispose $cloudDeviceEmulator correctly

### DIFF
--- a/lib/cloud-device-emulator.ts
+++ b/lib/cloud-device-emulator.ts
@@ -1,13 +1,17 @@
 export class CloudDeviceEmulatorWrapper implements ICloudDeviceEmulator {
-	private cloudDeviceEmulatorInstance: ICloudDeviceEmulator;
+	private _isCloudDeviceEmulatorInstanceInitialized = false;
+	private get cloudDeviceEmulatorInstance(): ICloudDeviceEmulator {
+		return require("cloud-device-emulator");
+	}
 
 	public get deviceEmitter(): CloudDeviceEmitter {
+		this._isCloudDeviceEmulatorInstanceInitialized = true;
 		return this.cloudDeviceEmulatorInstance.deviceEmitter;
 	}
 
 	constructor(private $options: IOptions,
+		private $usbLiveSyncService: any,
 		private $processService: IProcessService) {
-		this.cloudDeviceEmulatorInstance = require("cloud-device-emulator");
 		this.$processService.attachToProcessExitSignals(this, this._dispose);
 	}
 
@@ -24,13 +28,15 @@ export class CloudDeviceEmulatorWrapper implements ICloudDeviceEmulator {
 	}
 
 	public dispose() {
-		if (!this.$options.watch) {
+		if (!this.$options.watch || !this.$usbLiveSyncService.isInitialized) {
 			this._dispose();
 		}
 	}
 
 	private _dispose() {
-		this.cloudDeviceEmulatorInstance.deviceEmitter.dispose();
+		if (this._isCloudDeviceEmulatorInstanceInitialized) {
+			this.cloudDeviceEmulatorInstance.deviceEmitter.dispose();
+		}
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typescript": "2.1.5"
   },
   "dependencies": {
-    "cloud-device-emulator": "0.3.1",
+    "cloud-device-emulator": "0.3.2",
     "cookie": "0.3.1",
     "lodash": "4.17.4",
     "minimatch": "3.0.4",


### PR DESCRIPTION
Do not dispose `$cloudDeviceEmulator` if it hasn't been used.
Do not dispose `$cloudDeviceEmulator` if in the middle of LiveSync
Bump `cloud-device-emulator` version

Ping @TsvetanMilanov @rosen-vladimirov 