### PR TITLE
Check if server is running before killing it

### DIFF
--- a/lib/cloud-device-emulator.ts
+++ b/lib/cloud-device-emulator.ts
@@ -1,11 +1,11 @@
 export class CloudDeviceEmulatorWrapper implements ICloudDeviceEmulator {
 	private _isCloudDeviceEmulatorInstanceInitialized = false;
 	private get cloudDeviceEmulatorInstance(): ICloudDeviceEmulator {
+		this._isCloudDeviceEmulatorInstanceInitialized = true;
 		return require("cloud-device-emulator");
 	}
 
 	public get deviceEmitter(): CloudDeviceEmitter {
-		this._isCloudDeviceEmulatorInstanceInitialized = true;
 		return this.cloudDeviceEmulatorInstance.deviceEmitter;
 	}
 
@@ -23,8 +23,10 @@ export class CloudDeviceEmulatorWrapper implements ICloudDeviceEmulator {
 		return this.cloudDeviceEmulatorInstance.refresh(deviceIdentifier);
 	}
 
-	public killServer(): Promise<any> {
-		return this.cloudDeviceEmulatorInstance.killServer();
+	public async killServer(): Promise<any> {
+		if (this._isCloudDeviceEmulatorInstanceInitialized) {
+			return this.cloudDeviceEmulatorInstance.killServer();
+		}
 	}
 
 	public dispose() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {


### PR DESCRIPTION
There's no point in calling `killServer` when there is no server running. Attempting to do so will launch the server and then kill it.

In addition, fix location of `this._isCloudDeviceEmulatorInstanceInitialized = true`

Ping @rosen-vladimirov @TsvetanMilanov 