### PR TITLE
Add platform before building

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {


### PR DESCRIPTION
This mimics the local build closely and may prevent some future problems.
The short-term benefit is the fact that by adding a platform the runtime's version is written in the package.json and is therefore respected in the cloud.

Ping @TsvetanMilanov @rosen-vladimirov 