### PR TITLE
Fix cloud builds by preparing the project before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {


### PR DESCRIPTION
Currently we only add the platform before building the application. However, once we try to persist the `.nsbuildinfo` we fail with: `Cannot read property 'changesRequireBuildTime' of null`
The problem is that generating the `.nsbuildinfo` relies on the `.nsprepareinfo`, which is generated during prepare.

So instead of just calling add platform, change the code to call prepare platform. This way the `.nsprepareinfo` will be generated and the project will be prepared.