### PR TITLE
Pass mobileProvision data to prepare

### DIFF
--- a/lib/definitions/crypto-identities.d.ts
+++ b/lib/definitions/crypto-identities.d.ts
@@ -21,6 +21,7 @@ interface IMobileProvisionData {
 	TimeToLive: 365;
 	UUID: string;
 	Version: number;
+	Type?: string;
 }
 
 interface ICloudProvisionData {

--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -202,11 +202,18 @@ export class CloudBuildService extends EventEmitter implements ICloudBuildServic
 			release: buildConfiguration && buildConfiguration.toLowerCase() === constants.RELEASE_CONFIGURATION_NAME.toLowerCase()
 		};
 
-		const provisionData = iOSBuildData && iOSBuildData.pathToProvision && this.getMobileProvisionData(iOSBuildData.pathToProvision);
-		const provision = provisionData && provisionData.UUID;
+		let mobileProvisionData: IMobileProvisionData;
+		let provision: string;
+
+		if (iOSBuildData && iOSBuildData.pathToProvision) {
+			mobileProvisionData = this.getMobileProvisionData(iOSBuildData.pathToProvision);
+			mobileProvisionData.Type = this.getProvisionType(mobileProvisionData);
+			provision = mobileProvisionData.UUID;
+		}
 
 		const config: IAddPlatformCoreOptions = {
 			provision,
+			mobileProvisionData,
 			sdk: null,
 			frameworkPath: null,
 			ignoreScripts: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {


### PR DESCRIPTION
Pass the full mobileProvision data to prepare method, so it will not execute `security` command which is available only on macOS.