### PR TITLE
Prepare project before zipping the project

### DIFF
--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -48,6 +48,8 @@ export class CloudBuildService extends EventEmitter implements ICloudBuildServic
 		this.$logger.info(`Starting ${buildInformationString}.`);
 
 		await this.validateBuildProperties(platform, buildConfiguration, projectSettings.projectId, androidBuildData, iOSBuildData);
+		await this.prepareProject(projectSettings, platform, buildConfiguration, iOSBuildData);
+
 		let buildProps = await this.prepareBuildRequest(projectSettings, platform, buildConfiguration);
 
 		if (this.$mobileHelper.isAndroidPlatform(platform)) {
@@ -56,7 +58,6 @@ export class CloudBuildService extends EventEmitter implements ICloudBuildServic
 			buildProps = await this.getiOSBuildProperties(projectSettings, buildProps, iOSBuildData);
 		}
 
-		await this.prepareProject(projectSettings, platform, buildConfiguration, iOSBuildData);
 		const buildResponse: IBuildResponse = await this.$buildCloudService.startBuild(projectSettings.projectId, buildProps);
 		this.$logger.trace("Build response:");
 		this.$logger.trace(buildResponse);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {


### PR DESCRIPTION
Currently we prepare the project AFTER zipping it. This is not correct when the prepare executes `platform add` as we end-up without the `tns-<platform>` key in the package.json inside the .zip.