### PR TITLE
Create default .gitignore before initial commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {


### PR DESCRIPTION
Currently we create the `.gitignore` file right before calling `git push`. However, at this point the initial commit of files is already created and some special files (like `platforms` and `node_modules` directories) are pushed in the remote repository.
Fix this by creating the `.gitignore` at the beginning of the operation, before calling `git add` and `git commit`.
Also rename a method (just to make it clear what's the behavior of the method).