### PR TITLE
Use skipNativePrepare for cloud builds

### DIFF
--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -257,7 +257,7 @@ export class CloudBuildService extends EventEmitter implements ICloudBuildServic
 			ignoreScripts: false
 		};
 
-		await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, null, projectData, config);
+		await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, null, projectData, config, [], { skipNativePrepare: true });
 	}
 
 	private async getObjectFromS3File<T>(pathToFile: string): Promise<T> {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {


### PR DESCRIPTION
When preparing project from cloud services we do not count on local setup, so skip native preparation

Merge after - https://github.com/NativeScript/nativescript-cli/pull/2983

https://github.com/NativeScript/nativescript-cli/issues/2968