### PR TITLE
[WIP] Read cloud env from config files

### DIFF
--- a/lib/commands/config/config-reset.ts
+++ b/lib/commands/config/config-reset.ts
@@ -6,7 +6,8 @@ export class ConfigResetCommand implements ICommand {
 
 	public async execute(args: string[]): Promise<void> {
 		this.$serverConfigManager.reset();
-		this.$logger.info("Server configuration successfully reset.");
+		this.$logger.info("Server configuration successfully reset to:");
+		this.$serverConfigManager.printConfigData();
 	}
 }
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -68,6 +68,8 @@ export const HTTP_HEADERS = {
 	LOCATION: "Location"
 };
 
+export const CUSTOM_ENV_HEADER_PREFIX = "X-Fusion-Env-Var-";
+
 export const HTTP_STATUS_CODES = {
 	SUCCESS: 200,
 	FOUND: 302,

--- a/lib/definitions/definitions.d.ts
+++ b/lib/definitions/definitions.d.ts
@@ -1,0 +1,3 @@
+interface IDynamicIndex {
+	[index: string]: any;
+}

--- a/lib/definitions/server-config-manager.d.ts
+++ b/lib/definitions/server-config-manager.d.ts
@@ -18,21 +18,21 @@ interface IServerConfigManager {
 	printConfigData(): void;
 }
 
-interface IServerConfig {
+interface IServerConfig extends IDynamicIndex {
 	apiVersion?: string;
 	domainName: string;
 	serverProto?: string;
 	stage?: string;
+	cloudEnv?: IStringDictionary;
 	cloudServices: IDictionary<ICloudServiceConfig>;
-	[index: string]: string | IDictionary<ICloudServiceConfig>;
 }
 
-interface ICloudServiceConfig {
+interface ICloudServiceConfig extends IDynamicIndex {
 	apiVersion?: string;
 	fullHostName?: string;
 	serverProto?: string;
 	subdomain?: string;
-	[index: string]: string;
+	cloudEnv?: IStringDictionary;
 }
 
 /**

--- a/lib/server-config-manager.ts
+++ b/lib/server-config-manager.ts
@@ -32,7 +32,7 @@ export class ServerConfigManager implements IServerConfigManager {
 
 	public printConfigData(): void {
 		const config = this.getCurrentConfigData();
-		console.log(config);
+		console.log(JSON.stringify(config, null, "  "));
 	}
 
 	public getCurrentConfigData(): IServerConfig {

--- a/server-configs/config-base.json
+++ b/server-configs/config-base.json
@@ -1,5 +1,6 @@
 {
 	"apiVersion": "v1",
 	"domainName": "digitalfactory.rocks",
-	"serverProto": "https"
+	"serverProto": "https",
+	"cloudEnv": {}
 }


### PR DESCRIPTION
We can override some of the environment variables on our server by passing special headers. We should provide a way to set the env vars and their values in the headers of the request. The best place is in the server configuration files. The environment variables can be service specific or global.

Example:
```JSON
{
  "apiVersion": "v1",
  "domainName": "somedomain.com",
  "serverProto": "https",
  "stage": "production",
  "cloudServices": {
    "first-service": {
      "subdomain": "first",
      "cloudEnv": {
        "TEST": "TEST1"
      }
    },
    "second-service": {
      "subdomain": "second",
      "cloudEnv": {
        "TEST": "TEST2"
      }
    },
    "third-service": {
      "subdomain": "third"
    }
  },
  "cloudEnv": {
    "TEST": "TEST"
  }
}
```