### PR TITLE
Fix git builds

### DIFF
--- a/lib/mobile/device/cloud-emulator-device-file-system.ts
+++ b/lib/mobile/device/cloud-emulator-device-file-system.ts
@@ -7,7 +7,7 @@ export class CloudEmulatorDeviceFileSystem implements Mobile.IDeviceFileSystem {
 
 	public async transferFiles(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]): Promise<void> { /* currently empty */ }
 
-	public async transferDirectory(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string): Promise<void> { /* currently empty */ }
+	public async transferDirectory(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string): Promise<Mobile.ILocalToDevicePathData[]> { return []; }
 
 	public async transferFile(localPath: string, devicePath: string): Promise<void> { /* currently empty */ }
 

--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -28,7 +28,8 @@ export class CloudBuildService extends EventEmitter implements ICloudBuildServic
 		private $mobileHelper: Mobile.IMobileHelper,
 		private $projectHelper: IProjectHelper,
 		private $projectDataService: IProjectDataService,
-		private $qr: IQrCodeGenerator) {
+		private $qr: IQrCodeGenerator,
+		private $userService: IUserService) {
 		super();
 	}
 
@@ -388,7 +389,8 @@ export class CloudBuildService extends EventEmitter implements ICloudBuildServic
 				templateAppName: sanitizedProjectName,
 				projectName: sanitizedProjectName,
 				framework: "tns",
-				useIncrementalBuild: !projectSettings.clean
+				useIncrementalBuild: !projectSettings.clean,
+				userEmail: this.$userService.getUser().email
 			},
 			buildFiles
 		};

--- a/lib/services/git-service.ts
+++ b/lib/services/git-service.ts
@@ -20,7 +20,8 @@ export class GitService implements IGitService {
 		private $fs: IFileSystem,
 		private $hostInfo: IHostInfo,
 		private $logger: ILogger,
-		private $options: IProfileDir) { }
+		private $options: IProfileDir,
+		private $userService: IUserService) { }
 
 	public async gitPushChanges(projectDir: string, remoteUrl: IRemoteUrl, codeCommitCredential: ICodeCommitCredentials, repositoryState?: IRepositoryState): Promise<void> {
 		this.cleanLocalRepositories();
@@ -158,7 +159,7 @@ export class GitService implements IGitService {
 
 	private getGitDirName(projectDir: string): string {
 		const shasumData = crypto.createHash("sha1");
-		shasumData.update(projectDir);
+		shasumData.update(`${this.$userService.getUser().email}_${projectDir}`);
 		const gitDirName = shasumData.digest("hex");
 
 		return gitDirName;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {


### PR DESCRIPTION
When the user `X` builds project with name `test` we create local repository with name the sha1 of the project id.
If the user `Y` creates project with the same name on the same machine we put the new project in the same local repo.
User `Y` does not have credentials for the repo of user `X` and each git operation which requires the credentials fails with 403.
The solution is to include the user email in the repo name.

Also we need to pass `userEmail` in our build request properties because we need it in our build tooling.