### PR TITLE
Add cloud build steps

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -25,7 +25,8 @@ export const EMULATORS_SERVICE_NAME = "emulators-service";
 export const CODE_COMMIT_SERVICE_NAME = "code-commit-service";
 
 export const CLOUD_BUILD_EVENT_NAMES = {
-	BUILD_OUTPUT: "buildOutput"
+	BUILD_OUTPUT: "buildOutput",
+	STEP_CHANGED: "stepChanged"
 };
 
 export const DEVICE_DISCOVERY_EVENTS = {
@@ -82,4 +83,16 @@ export const DISPOSITIONS = {
 	PROVISION: "Provision",
 	KEYCHAIN: "Keychain",
 	CRYPTO_STORE: "CryptoStore"
+};
+
+export const BUILD_STEP_NAME = {
+	PREPARE: "prepare",
+	UPLOAD: "upload",
+	BUILD: "build",
+	DOWNLOAD: "download"
+};
+
+export const BUILD_STEP_PROGRESS = {
+	START: 0,
+	END: 100
 };

--- a/lib/definitions/cloud-build-service.d.ts
+++ b/lib/definitions/cloud-build-service.d.ts
@@ -3,6 +3,11 @@
  */
 interface IBuildResultData {
 	/**
+	 * The ID of the build.
+	 */
+	buildId: string;
+
+	/**
 	 * All data printed to the stderr during cloud build operation.
 	 */
 	stderr: string;
@@ -26,6 +31,36 @@ interface IBuildResultData {
 	 * Data required for generation of a QR code from the build result.
 	 */
 	qrData: IQrData;
+}
+
+/**
+ * Describes build step.
+ */
+interface IBuildStep {
+	/**
+	 * The ID of the build.
+	 */
+	buildId: string;
+
+	/**
+	 * The name of the step.
+	 */
+	step: string;
+
+	/**
+	 * The progress of the step in percents. The value will be between 0 and 100.
+	 */
+	progress: number;
+}
+
+interface IBuildError extends Error {
+	buildId: string;
+}
+
+interface IBuildLog {
+	buildId: string;
+	data: string;
+	pipe: string;
 }
 
 /**


### PR DESCRIPTION
Build steps:
- prepare
- upload
- build
- download

The `cloudBuildService` will emit `buildStepChanged` event for each step.
Each object will have build ID, step name and a progress which will be a number between 0 and 100%.

These build steps will be used for profiling the build and some kind of progress indicator in the clients of the extension.

> Note: I will update the README.md after the review of the functionality.