### PR TITLE
Implement codesign cloud service and command

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -12,6 +12,7 @@ $injector.require("cloudEmulatorDeviceDiscovery", path.join(__dirname, "mobile",
 // Public API.
 $injector.requirePublicClass("authenticationService", path.join(__dirname, "services", "authentication-service"));
 $injector.requirePublicClass("cloudBuildService", path.join(__dirname, "services", "cloud-build-service"));
+$injector.requirePublicClass("cloudCodesignService", path.join(__dirname, "services", "cloud-codesign-service"));
 $injector.requirePublicClass("cloudEmulatorLauncher", path.join(__dirname, "services", "cloud-emulator-emulator-launcher"));
 $injector.requirePublicClass("userService", path.join(__dirname, "services", "user-service"));
 
@@ -40,6 +41,7 @@ $injector.requireCommand("user", path.join(__dirname, "commands", "user"));
 $injector.requireCommand("kill-server", path.join(__dirname, "commands", "kill-server"));
 
 $injector.requireCommand("build|cloud", path.join(__dirname, "commands", "cloud-build"));
+$injector.requireCommand("codesign|cloud", path.join(__dirname, "commands", "cloud-codesign"));
 $injector.requireCommand("cloud|lib|version", path.join(__dirname, "commands", "cloud-lib-version"));
 
 const $devicesService: Mobile.IDevicesService = $injector.resolve("devicesService");

--- a/lib/commands/cloud-build.ts
+++ b/lib/commands/cloud-build.ts
@@ -14,7 +14,7 @@ export class CloudBuild implements ICommand {
 
 	public async execute(args: string[]): Promise<void> {
 		const platform = this.$mobileHelper.validatePlatformName(args[0]);
-		this.$logger.warn(`Executing cloud build with platform: ${platform}.`);
+		this.$logger.info(`Executing cloud build with platform: ${platform}.`);
 		const nativescriptData = this.$fs.readJson(path.join(this.$projectData.projectDir, "package.json")).nativescript;
 		let pathToCertificate = "";
 		if (this.$mobileHelper.isAndroidPlatform(platform)) {

--- a/lib/commands/cloud-codesign.ts
+++ b/lib/commands/cloud-codesign.ts
@@ -1,7 +1,11 @@
-export class CloudCodesign implements ICommand {
+import { isInteractive } from "../helpers";
+
+export class CloudCodesignCommand implements ICommand {
+	private parametersValidationText = "The command has only 3 valid parameters - Apple account id, Apple account password and optional parameter clean for force re-invokation of certificate, if any.";
 	public allowedParameters: ICommandParameter[];
 
 	constructor(private $logger: ILogger,
+		private $errors: IErrors,
 		private $projectData: IProjectData,
 		private $prompter: IPrompter,
 		private $options: IOptions,
@@ -14,21 +18,33 @@ export class CloudCodesign implements ICommand {
 		let password = args[1];
 
 		if (!username) {
-			username = await this.$prompter.getString("Apple ID", { allowEmpty: false });
+			if (isInteractive) {
+				username = await this.$prompter.getString("Apple ID", { allowEmpty: false });
+			} else {
+				this.$errors.fail(this.parametersValidationText);
+			}
 		}
 
 		if (!password) {
-			password = await this.$prompter.getPassword("Apple ID password");
+			if (isInteractive) {
+				password = await this.$prompter.getPassword("Apple ID password");
+			} else {
+				this.$errors.fail(this.parametersValidationText);
+			}
 		}
 
-		this.$logger.info("Executing cloud codesign command");
+		this.$logger.info("Generating codesign files in the cloud");
 		const codesignData = { username, password, clean: this.$options.clean };
-		await this.$cloudCodesignService.generateCodesignFiles(codesignData, this.$projectData);
+		await this.$cloudCodesignService.generateCodesignFiles(codesignData, this.$projectData.projectDir);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {
+		if (args.length > 3) {
+			this.$errors.fail(this.parametersValidationText);
+		}
+
 		return true;
 	}
 }
 
-$injector.registerCommand("codesign|cloud", CloudCodesign);
+$injector.registerCommand("codesign|cloud", CloudCodesignCommand);

--- a/lib/commands/cloud-codesign.ts
+++ b/lib/commands/cloud-codesign.ts
@@ -1,10 +1,15 @@
 import { isInteractive } from "../helpers";
 
 export class CloudCodesignCommand implements ICommand {
-	private parametersValidationText = "The command has only 3 valid parameters - Apple account id, Apple account password and optional parameter clean for force re-invokation of certificate, if any.";
+	private readonly parametersValidationText = "The command has only two valid parameters - Apple account id and Apple account password.";
+	// Currently only iOS codesign generation is supported.
+	private readonly platform = this.$devicePlatformsConstants.iOS;
+	private devices: Mobile.IDeviceInfo[];
 	public allowedParameters: ICommandParameter[];
 
 	constructor(private $logger: ILogger,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		private $devicesService: Mobile.IDevicesService,
 		private $errors: IErrors,
 		private $projectData: IProjectData,
 		private $prompter: IPrompter,
@@ -18,29 +23,36 @@ export class CloudCodesignCommand implements ICommand {
 		let password = args[1];
 
 		if (!username) {
-			if (isInteractive) {
-				username = await this.$prompter.getString("Apple ID", { allowEmpty: false });
-			} else {
-				this.$errors.fail(this.parametersValidationText);
-			}
+			username = await this.$prompter.getString("Apple ID", { allowEmpty: false });
 		}
 
 		if (!password) {
-			if (isInteractive) {
-				password = await this.$prompter.getPassword("Apple ID password");
-			} else {
-				this.$errors.fail(this.parametersValidationText);
-			}
+			password = await this.$prompter.getPassword("Apple ID password");
 		}
 
 		this.$logger.info("Generating codesign files in the cloud");
-		const codesignData = { username, password, clean: this.$options.clean };
+
+		const codesignData = {
+			username, password,
+			clean: this.$options.clean,
+			platform: this.platform,
+			attachedDevices: this.devices
+		};
+
 		await this.$cloudCodesignService.generateCodesignFiles(codesignData, this.$projectData.projectDir);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {
-		if (args.length > 3) {
+		if (args.length > 2 || (!isInteractive() && args.length < 2)) {
 			this.$errors.fail(this.parametersValidationText);
+		}
+
+		await this.$devicesService.detectCurrentlyAttachedDevices({ shouldReturnImmediateResult: false, platform: this.platform });
+		this.devices = this.$devicesService.getDeviceInstances()
+			.filter(d => !d.isEmulator && d.deviceInfo.platform.toLowerCase() === this.platform.toLowerCase())
+			.map(d => d.deviceInfo);
+		if (!this.devices || this.devices.length === 0) {
+			this.$errors.fail("Please attach iOS devices for which to generate codesign files.");
 		}
 
 		return true;

--- a/lib/commands/cloud-codesign.ts
+++ b/lib/commands/cloud-codesign.ts
@@ -1,0 +1,34 @@
+export class CloudCodesign implements ICommand {
+	public allowedParameters: ICommandParameter[];
+
+	constructor(private $logger: ILogger,
+		private $projectData: IProjectData,
+		private $prompter: IPrompter,
+		private $options: IOptions,
+		private $cloudCodesignService: ICloudCodesignService) {
+		this.$projectData.initializeProjectData();
+	}
+
+	public async execute(args: string[]): Promise<void> {
+		let username = args[0];
+		let password = args[1];
+
+		if (!username) {
+			username = await this.$prompter.getString("Apple ID", { allowEmpty: false });
+		}
+
+		if (!password) {
+			password = await this.$prompter.getPassword("Apple ID password");
+		}
+
+		this.$logger.info("Executing cloud codesign command");
+		const codesignData = { username, password, clean: this.$options.clean };
+		await this.$cloudCodesignService.generateCodesignFiles(codesignData, this.$projectData);
+	}
+
+	public async canExecute(args: string[]): Promise<boolean> {
+		return true;
+	}
+}
+
+$injector.registerCommand("codesign|cloud", CloudCodesign);

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,5 +1,5 @@
 export const CLOUD_TEMP_DIR_NAME = ".cloud";
-export const CODESIGN_TEMP_DIR_NAME = ".codesign";
+export const CODESIGN_FILES_DIR_NAME = "codesign_files";
 export const RELEASE_CONFIGURATION_NAME = "release";
 
 export const CRYPTO = {

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,4 +1,5 @@
 export const CLOUD_TEMP_DIR_NAME = ".cloud";
+export const CODESIGN_TEMP_DIR_NAME = ".codesign";
 export const RELEASE_CONFIGURATION_NAME = "release";
 
 export const CRYPTO = {
@@ -81,6 +82,7 @@ export const DISPOSITIONS = {
 	PACKAGE_GIT: "PackageGit",
 	BUILD_RESULT: "BuildResult",
 	PROVISION: "Provision",
+	CERTIFICATE: "Certificate",
 	KEYCHAIN: "Keychain",
 	CRYPTO_STORE: "CryptoStore"
 };

--- a/lib/definitions/cloud-build-service.d.ts
+++ b/lib/definitions/cloud-build-service.d.ts
@@ -189,3 +189,9 @@ interface IIOSBuildData extends IBuildForDevice {
 	 */
 	deviceIdentifier?: string;
 }
+
+/**
+ * Here only for backwards compatibility.
+ */
+interface ICloudBuildOutputDirectoryOptions extends ICloudServerOutputDirectoryOptions {
+}

--- a/lib/definitions/cloud-build-service.d.ts
+++ b/lib/definitions/cloud-build-service.d.ts
@@ -1,27 +1,7 @@
 /**
  * Describes the result of a cloud build operation.
  */
-interface IBuildResultData {
-	/**
-	 * The ID of the build.
-	 */
-	buildId: string;
-
-	/**
-	 * All data printed to the stderr during cloud build operation.
-	 */
-	stderr: string;
-
-	/**
-	 * All data printed to the stdout during cloud build operation.
-	 */
-	stdout: string;
-
-	/**
-	 * The full ordered output - combination for stderr and stdout, but ordered in correct timeline.
-	 */
-	fullOutput: string;
-
+interface IBuildResultData extends IServerResultData {
 	/**
 	 * Path to the downloaded result of the build operation - .apk, .ipa...
 	 */
@@ -81,7 +61,7 @@ interface IQrData {
 /**
  * Defines operations for building a project in the cloud.
  */
-interface ICloudBuildService {
+interface ICloudBuildService extends ICloudOperationService {
 	/**
 	 * Builds the specified application in the cloud and returns information about the whole build process.
 	 * @param {IProjectSettings} projectSettings Describes the current project - project dir, application identifier, name and nativescript data.
@@ -111,13 +91,6 @@ interface ICloudBuildService {
 		projectId: string,
 		androidBuildData?: IAndroidBuildData,
 		iOSBuildData?: IIOSBuildData): Promise<void>;
-
-	/**
-	 * Returns the path to the directory where the build output may be found.
-	 * @param {ICloudBuildOutputDirectoryOptions} options Options that are used to determine the build output directory.
-	 * @returns {string} The build output directory.
-	 */
-	getBuildOutputDirectory(options: ICloudBuildOutputDirectoryOptions): string;
 }
 
 /**
@@ -215,56 +188,4 @@ interface IIOSBuildData extends IBuildForDevice {
 	 * In case you pass the deviceIdentifier and it is not included in the specified provision, the operation will fail.
 	 */
 	deviceIdentifier?: string;
-}
-
-/**
- * Describes the status of the build.
- */
-interface IBuildStatus {
-	/**
-	 * The build status.
-	 */
-	status: string;
-}
-
-/**
- * Describes options that can be passed in order to specify the exact location of the built package.
- */
-interface ICloudBuildOutputDirectoryOptions {
-	/**
-	 * Android or iOS
-	 */
-	platform: string;
-
-	/**
-	 * Directory where the project is located.
-	 */
-	projectDir: string;
-
-	/**
-	 * Whether the build is for emulator or not.
-	 */
-	emulator?: boolean;
-}
-
-/**
- * Describes the result from the build.
- */
-interface IBuildResult {
-	errors: string[];
-	code: number;
-	stdout: string;
-	stderr: string;
-	buildItems: IBuildItem[];
-}
-
-interface IBuildItemBase {
-	disposition: string;
-	filename: string;
-	fullPath: string;
-}
-
-interface IBuildItem extends IBuildItemBase {
-	platform: string;
-	extension: string;
 }

--- a/lib/definitions/cloud-codesign-service.d.ts
+++ b/lib/definitions/cloud-codesign-service.d.ts
@@ -13,7 +13,7 @@ interface ICodesignResultData extends IServerResultData {
  */
 interface ICodesignData extends ICredentials {
 	/**
-	 * Whether to revoke and reissue certificate even if it is not expired. This option is necessary as re-downloading the .p12 file is imposible.
+	 * Whether to revoke and reissue certificate even if it is not expired. This option is necessary as re-downloading the .p12 file is impossible.
 	 * It provides consumers with opportunity to deliberately reissue account's development certificate. It will default to true as it is the excpected behaviour.
 	 */
 	clean?: boolean;
@@ -25,9 +25,9 @@ interface ICodesignData extends ICredentials {
 interface ICloudCodesignService extends ICloudOperationService {
 	/**
 	 * Generates codesign files in the cloud and returns s3 urls to certificate or/and provision.
-	 * @param {ICodesignData} codesignData apple speicific information.
-	 * @param {IProjectData} projectData DTO with information about the project.
+	 * @param {ICodesignData} codesignData Apple speicific information.
+	 * @param {string} projectDir The path of the project.
 	 * @returns {Promise<ICodesignResultData>} Information about the generation process. It is returned only on successfull generation. In case there is some error, the Promise is rejected with the server information.
 	 */
-	generateCodesignFiles(codesignData: ICodesignData, projectData: IProjectData): Promise<ICodesignResultData>;
+	generateCodesignFiles(codesignData: ICodesignData, projectDir: string): Promise<ICodesignResultData>;
 }

--- a/lib/definitions/cloud-codesign-service.d.ts
+++ b/lib/definitions/cloud-codesign-service.d.ts
@@ -14,9 +14,14 @@ interface ICodesignResultData extends IServerResultData {
 interface ICodesignData extends ICredentials {
 	/**
 	 * Whether to revoke and reissue certificate even if it is not expired. This option is necessary as re-downloading the .p12 file is impossible.
-	 * It provides consumers with opportunity to deliberately reissue account's development certificate. It will default to true as it is the excpected behaviour.
+	 * It provides consumers with opportunity to deliberately reissue account's development certificate. It will default to true as it is the expected behaviour.
 	 */
 	clean?: boolean;
+	/**
+	 * To generate development codesign files Apple API requires devices as development provisions are only issued per them.
+	 */
+	attachedDevices: Mobile.IDeviceInfo[];
+	platform: string;
 }
 
 /**

--- a/lib/definitions/cloud-codesign-service.d.ts
+++ b/lib/definitions/cloud-codesign-service.d.ts
@@ -1,0 +1,33 @@
+/**
+ * Describes the result of a cloud codesign operation (i.e. generation of codesign files for iOS builds).
+ */
+interface ICodesignResultData extends IServerResultData {
+	/**
+	 * Path to the downloaded results of the codesign generation - .p12, .mobileprovision
+	 */
+	outputFilesPaths: string[];
+}
+
+/**
+ *  Describes specific data required for codesigning files to be generated.
+ */
+interface ICodesignData extends ICredentials {
+	/**
+	 * Whether to revoke and reissue certificate even if it is not expired. This option is necessary as re-downloading the .p12 file is imposible.
+	 * It provides consumers with opportunity to deliberately reissue account's development certificate. It will default to true as it is the excpected behaviour.
+	 */
+	clean?: boolean;
+}
+
+/**
+ * Defines operations for generation codesign files in the cloud.
+ */
+interface ICloudCodesignService extends ICloudOperationService {
+	/**
+	 * Generates codesign files in the cloud and returns s3 urls to certificate or/and provision.
+	 * @param {ICodesignData} codesignData apple speicific information.
+	 * @param {IProjectData} projectData DTO with information about the project.
+	 * @returns {Promise<ICodesignResultData>} Information about the generation process. It is returned only on successfull generation. In case there is some error, the Promise is rejected with the server information.
+	 */
+	generateCodesignFiles(codesignData: ICodesignData, projectData: IProjectData): Promise<ICodesignResultData>;
+}

--- a/lib/definitions/cloud-service.d.ts
+++ b/lib/definitions/cloud-service.d.ts
@@ -1,0 +1,87 @@
+/**
+ * Describes the result of a server operation.
+ */
+interface IServerResultData {
+	/**
+	 * The ID of the operation - usually named buildId due to initial implementation that is related to other repos.
+	 */
+	buildId: string;
+
+	/**
+	 * All data printed to the stderr during server operation.
+	 */
+	stderr: string;
+
+	/**
+	 * All data printed to the stdout during server operation.
+	 */
+	stdout: string;
+
+	/**
+	 * The full ordered output - combination for stderr and stdout, but ordered in correct timeline.
+	 */
+	fullOutput: string;
+}
+
+/**
+ * Describes the status of the server operation.
+ */
+interface IServerStatus {
+	/**
+	 * The build status.
+	 */
+	status: string;
+}
+
+/**
+ * Describes options that can be passed in order to specify the exact location of the built package.
+ */
+interface ICloudServerOutputDirectoryOptions {
+	/**
+	 * Android or iOS - currently only iOS implementation is available
+	 */
+	platform: string;
+
+	/**
+	 * Directory where the project is located.
+	 */
+	projectDir: string;
+
+	/**
+	 * Whether the build is for emulator or not.
+	 */
+	emulator?: boolean;
+}
+
+/**
+ * Describes the result from the server operation.
+ */
+interface IServerResult {
+	errors: string[];
+	code: number;
+	stdout: string;
+	stderr: string;
+	buildItems: IServerItem[]; // naming is die to initial implementation that is related to other repos.
+}
+
+interface IServerItemBase {
+	disposition: string;
+	filename: string;
+	fullPath: string;
+}
+
+interface IServerItem extends IServerItemBase {
+	platform: string;
+	extension: string;
+}
+/**
+ * Defines common operations for server operation in the cloud.
+ */
+interface ICloudOperationService {
+	/**
+	 * Returns the path to the directory where the build output may be found.
+	 * @param {ICloudServerOutputDirectoryOptions} options Options that are used to determine the build output directory.
+	 * @returns {string} The build output directory.
+	 */
+	getServerOperationOutputDirectory(options: ICloudServerOutputDirectoryOptions): string;
+}

--- a/lib/definitions/cloud-service.d.ts
+++ b/lib/definitions/cloud-service.d.ts
@@ -61,7 +61,11 @@ interface IServerResult {
 	code: number;
 	stdout: string;
 	stderr: string;
-	buildItems: IServerItem[]; // naming is due to initial implementation that is related to other repos.
+	/**
+	 * Items produced after execution of server command. Could be empty.
+	 * Naming is due to initial implementation that is related to other repos.
+	 */
+	buildItems: IServerItem[];
 }
 
 interface IServerItemBase {

--- a/lib/definitions/cloud-service.d.ts
+++ b/lib/definitions/cloud-service.d.ts
@@ -28,7 +28,7 @@ interface IServerResultData {
  */
 interface IServerStatus {
 	/**
-	 * The build status.
+	 * The status of the server operation.
 	 */
 	status: string;
 }
@@ -61,7 +61,7 @@ interface IServerResult {
 	code: number;
 	stdout: string;
 	stderr: string;
-	buildItems: IServerItem[]; // naming is die to initial implementation that is related to other repos.
+	buildItems: IServerItem[]; // naming is due to initial implementation that is related to other repos.
 }
 
 interface IServerItemBase {

--- a/lib/definitions/cloud-services/build-cloud-service.d.ts
+++ b/lib/definitions/cloud-services/build-cloud-service.d.ts
@@ -1,24 +1,24 @@
 interface IBuildCloudService {
-	startBuild(appId: string, buildRequest: IBuildRequestData): Promise<IBuildResponse>;
+	startBuild(appId: string, buildRequest: IBuildRequestData): Promise<IServerResponse>;
 	getPresignedUploadUrlObject(appId: string, fileName: string): Promise<IAmazonStorageEntry>;
 	getBuildCredentials(buildCredentialRequest: IBuildCredentialRequest): Promise<IBuildCredentialResponse>;
+	generateCodesignFiles(codesignRequestData: IServerRequestData): Promise<IServerResponse>;
 }
 
-interface IBuildResponse {
+interface IServerResponse {
 	statusUrl: string;
 	resultUrl: string;
 	outputUrl: string;
 }
 
 interface IBuildFile {
-	Disposition: string;
-	SourceUri: string;
+	disposition: string;
+	sourceUri: string;
 }
 
-interface IBuildRequestData {
-	Targets: string[];
-	Properties: IDictionary<string>;
-	BuildFiles: IBuildFile[];
+interface IBuildRequestData extends IServerRequestData {
+	targets: string[];
+	buildFiles: IBuildFile[];
 }
 
 interface IBuildCredentialRequest {
@@ -38,4 +38,8 @@ interface IAmazonStorageEntry {
 	publicDownloadUrl: string;
 	s3Url: string;
 	fileName: string;
+}
+
+interface IServerRequestData {
+	properties: IDictionary<any>;
 }

--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -15,11 +15,9 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 	protected get failedError() {
 		return "Build failed.";
 	};
+
 	protected get failedToStartError() {
 		return "Failed to start cloud build.";
-	};
-	protected get operationInProgressStatus() {
-		return "Building";
 	};
 
 	constructor($fs: IFileSystem,

--- a/lib/services/cloud-codesign-service.ts
+++ b/lib/services/cloud-codesign-service.ts
@@ -1,0 +1,133 @@
+import * as path from "path";
+import * as uuid from "uuid";
+import * as constants from "../constants";
+import { CloudService } from "./cloud-service";
+
+export class CloudCodesignService extends CloudService implements ICloudCodesignService {
+	private platform = this.$devicePlatformsConstants.iOS;
+
+	protected failedError: string;
+	protected failedToStartError: string;
+	protected operationInProgressStatus: string;
+
+	constructor($fs: IFileSystem,
+		$httpClient: Server.IHttpClient,
+		$logger: ILogger,
+		private $buildCloudService: IBuildCloudService,
+		private $errors: IErrors,
+		private $devicesService: Mobile.IDevicesService,
+		private $projectHelper: IProjectHelper,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) {
+		super($fs, $httpClient, $logger);
+		this.failedToStartError = "Failed to start cloud codesign generation.";
+		this.failedError = "Codesign generation failed.";
+		this.operationInProgressStatus = "Working";
+	}
+
+	public async generateCodesignFiles(codesignData: ICodesignData,
+		projectData: IProjectData): Promise<ICodesignResultData> {
+		codesignData.clean = codesignData.clean === undefined ? true : codesignData.clean;
+		const buildId = uuid.v4();
+
+		try {
+			const serverResult = await this.executeGeneration(codesignData, projectData, buildId);
+			return serverResult;
+		} catch (err) {
+			err.buildId = buildId;
+			throw err;
+		}
+	}
+
+	public getServerOperationOutputDirectory(options: ICloudServerOutputDirectoryOptions): string {
+		return path.join(options.projectDir, constants.CODESIGN_TEMP_DIR_NAME, options.platform.toLowerCase());
+	}
+
+	protected getServerResults(codesignResult: IServerResult): IServerItem[] {
+		const result = _.filter(codesignResult.buildItems, b => b.disposition === constants.DISPOSITIONS.CERTIFICATE
+			|| b.disposition === constants.DISPOSITIONS.PROVISION);
+
+		if (!result) {
+			this.$errors.failWithoutHelp(
+				`No item with disposition ${constants.DISPOSITIONS.CERTIFICATE} or ${constants.DISPOSITIONS.PROVISION} found in the server result items.`);
+		}
+
+		return result;
+	}
+
+	protected async getServerLogs(logsUrl: string, buildId: string): Promise<void> {
+		// no specific implementation needed.
+	}
+
+	public async executeGeneration(codesignData: ICodesignData,
+		projectData: IProjectData,
+		buildId: string): Promise<ICodesignResultData> {
+		const codesignInformationString = "Generation of iOS certificate and provision files";
+		this.$logger.info(`Starting ${codesignInformationString}.`);
+
+		const codesignRequest = await this.prepareCodesignRequest(buildId, codesignData, projectData);
+		const codesignResponse: IServerResponse = await this.$buildCloudService.generateCodesignFiles(codesignRequest);
+		this.$logger.trace(`Codesign response: ${JSON.stringify(codesignResponse)}`);
+
+		let codesignResult: IServerResult;
+		try {
+			await this.waitForServerOperationToFinish(buildId, codesignResponse);
+		} catch (ex) {
+			this.$logger.trace("Codesign generation failed with err: ", ex);
+		} finally {
+			codesignResult = await this.getObjectFromS3File<IServerResult>(codesignResponse.resultUrl);
+		}
+
+		this.$logger.trace("Codesign result:");
+		this.$logger.trace(codesignResult);
+
+		if (!codesignResult.buildItems || !codesignResult.buildItems.length) {
+			// Something failed.
+			this.$errors.failWithoutHelp(`Codesign failed. Reason is: ${codesignResult.errors}. Additional information: ${codesignResult.stderr}.`);
+		}
+
+		this.$logger.info(`Finished ${codesignInformationString} successfully. Downloading result...`);
+
+		const localCodesignResults = await this.downloadServerResults(codesignResult, {
+			projectDir: projectData.projectDir,
+			platform: this.platform,
+			emulator: false
+		});
+
+		this.$logger.info(`The result of ${codesignInformationString} successfully downloaded. Codesign files paths: ${localCodesignResults}`);
+
+		const fullOutput = await this.getContentOfS3File(codesignResponse.resultUrl);
+
+		const result = {
+			buildId,
+			stderr: codesignResult.stderr,
+			stdout: codesignResult.stdout,
+			fullOutput: fullOutput,
+			outputFilesPaths: localCodesignResults
+		};
+
+		return result;
+	}
+
+	private async prepareCodesignRequest(buildId: string,
+		codesignData: ICodesignData,
+		projectData: IProjectData): Promise<any> {
+
+		const sanitizedProjectName = this.$projectHelper.sanitizeName(projectData.projectName);
+		await this.$devicesService.detectCurrentlyAttachedDevices({ shouldReturnImmediateResult: false, platform: this.platform });
+		let attachedDevices = this.$devicesService.getDeviceInstances();
+		attachedDevices = attachedDevices.filter(d => d.deviceInfo.platform.toLowerCase() === this.platform.toLowerCase());
+		const devices = attachedDevices.map(d => ({ displayName: d.deviceInfo.displayName, identifier: d.deviceInfo.identifier }));
+
+		return {
+			buildId,
+			appId: projectData.projectId,
+			appName: sanitizedProjectName,
+			clean: codesignData.clean,
+			username: codesignData.username,
+			password: codesignData.password,
+			devices: devices
+		};
+	}
+}
+
+$injector.register("cloudCodesignService", CloudCodesignService);

--- a/lib/services/cloud-service.ts
+++ b/lib/services/cloud-service.ts
@@ -1,0 +1,100 @@
+import * as path from "path";
+import { EventEmitter } from "events";
+
+export abstract class CloudService extends EventEmitter {
+	private static OPERATION_STATUS_CHECK_INTERVAL = 1500;
+	private static OPERATION_COMPLETE_STATUS = "Success";
+	private static OPERATION_FAILED_STATUS = "Failed";
+
+	protected outputCursorPosition: number;
+	protected abstract failedToStartError: string;
+	protected abstract failedError: string;
+	protected abstract operationInProgressStatus: string;
+	protected abstract getServerResults(serverResult: IServerResult): IServerItem[];
+	protected abstract getServerLogs(logsUrl: string, buildId: string): Promise<void>;
+
+	public abstract getServerOperationOutputDirectory(options: ICloudServerOutputDirectoryOptions): string;
+
+	constructor(protected $fs: IFileSystem,
+		protected $httpClient: Server.IHttpClient,
+		protected $logger: ILogger) {
+		super();
+	}
+
+	protected async getObjectFromS3File<T>(pathToFile: string): Promise<T> {
+		return JSON.parse(await this.getContentOfS3File(pathToFile));
+	}
+
+	protected async getContentOfS3File(pathToFile: string): Promise<string> {
+		return (await this.$httpClient.httpRequest(pathToFile)).body;
+	}
+
+	protected waitForServerOperationToFinish(buildId: string, serverInformation: IServerResponse): Promise<void> {
+		return new Promise<void>((resolve, reject) => {
+			this.outputCursorPosition = 0;
+			let hasCheckedForServerStatus = false;
+			const serverIntervalId = setInterval(async () => {
+				let serverStatus: IServerStatus;
+				try {
+					serverStatus = await this.getObjectFromS3File<IServerStatus>(serverInformation.statusUrl);
+				} catch (err) {
+					this.$logger.trace(err);
+				}
+
+				if (!hasCheckedForServerStatus) {
+					hasCheckedForServerStatus = true;
+				} else if (!serverStatus) {
+					// We will get here if there is no server status twice in a row.
+					clearInterval(serverIntervalId);
+					return reject(new Error(this.failedToStartError));
+				}
+
+				if (!serverStatus) {
+					return;
+				}
+
+				if (serverStatus.status === CloudService.OPERATION_COMPLETE_STATUS) {
+					clearInterval(serverIntervalId);
+					await this.getServerLogs(serverInformation.outputUrl, buildId);
+
+					return resolve();
+				}
+
+				if (serverStatus.status === CloudService.OPERATION_FAILED_STATUS) {
+					clearInterval(serverIntervalId);
+					await this.getServerLogs(serverInformation.outputUrl, buildId);
+
+					return reject(new Error(this.failedError));
+				}
+
+				if (serverStatus.status === this.operationInProgressStatus) {
+					await this.getServerLogs(serverInformation.outputUrl, buildId);
+				}
+			}, CloudService.OPERATION_STATUS_CHECK_INTERVAL);
+		});
+	}
+
+	protected async downloadServerResults(serverResult: IServerResult, serverOutputOptions: ICloudServerOutputDirectoryOptions): Promise<string[]> {
+
+		const destinationDir = this.getServerOperationOutputDirectory(serverOutputOptions);
+		this.$fs.ensureDirectoryExists(destinationDir);
+
+		const serverResultObjs = this.getServerResults(serverResult);
+
+		let targetFileNames: string[] = [];
+		for (const serverResultObj of serverResultObjs) {
+			const targetFileName = path.join(destinationDir, serverResultObj.filename);
+			targetFileNames.push(targetFileName);
+			const targetFile = this.$fs.createWriteStream(targetFileName);
+
+			// Download the output file.
+			await this.$httpClient.httpRequest({
+				url: serverResultObj.fullPath,
+				pipeTo: targetFile
+			});
+		};
+
+		return targetFileNames;
+	}
+
+}

--- a/lib/services/cloud-service.ts
+++ b/lib/services/cloud-service.ts
@@ -5,11 +5,11 @@ export abstract class CloudService extends EventEmitter {
 	private static OPERATION_STATUS_CHECK_INTERVAL = 1500;
 	private static OPERATION_COMPLETE_STATUS = "Success";
 	private static OPERATION_FAILED_STATUS = "Failed";
+	private static OPERATION_IN_PROGRESS_STATUS = "Building";
 
 	protected outputCursorPosition: number;
 	protected abstract failedToStartError: string;
 	protected abstract failedError: string;
-	protected abstract operationInProgressStatus: string;
 	protected abstract getServerResults(serverResult: IServerResult): IServerItem[];
 	protected abstract getServerLogs(logsUrl: string, buildId: string): Promise<void>;
 
@@ -67,7 +67,7 @@ export abstract class CloudService extends EventEmitter {
 					return reject(new Error(this.failedError));
 				}
 
-				if (serverStatus.status === this.operationInProgressStatus) {
+				if (serverStatus.status === CloudService.OPERATION_IN_PROGRESS_STATUS) {
 					await this.getServerLogs(serverInformation.outputUrl, buildId);
 				}
 			}, CloudService.OPERATION_STATUS_CHECK_INTERVAL);

--- a/lib/services/cloud-services/build-cloud-service.ts
+++ b/lib/services/cloud-services/build-cloud-service.ts
@@ -9,8 +9,8 @@ export class BuildCloudService extends CloudServiceBase implements IBuildCloudSe
 		super($cloudRequestService);
 	}
 
-	public startBuild(appId: string, buildRequest: IBuildRequestData): Promise<IBuildResponse> {
-		return this.sendRequest<IBuildResponse>(HTTP_METHODS.POST, "api/build", buildRequest);
+	public startBuild(appId: string, buildRequest: IBuildRequestData): Promise<IServerResponse> {
+		return this.sendRequest<IServerResponse>(HTTP_METHODS.POST, "api/build", buildRequest);
 	}
 
 	public getPresignedUploadUrlObject(appId: string, fileName: string): Promise<IAmazonStorageEntry> {
@@ -19,6 +19,10 @@ export class BuildCloudService extends CloudServiceBase implements IBuildCloudSe
 
 	public getBuildCredentials(buildCredentialRequest: IBuildCredentialRequest): Promise<IBuildCredentialResponse> {
 		return this.sendRequest<IBuildCredentialResponse>(HTTP_METHODS.POST, "api/build-credentials", buildCredentialRequest);
+	}
+
+	public generateCodesignFiles(codesignRequestData: IServerRequestData): Promise<IServerResponse> {
+		return this.sendRequest<IServerResponse>(HTTP_METHODS.POST, "api/codesign", codesignRequestData);
 	}
 }
 


### PR DESCRIPTION
There is new server logic for generation of iOS codesign files. With providing apple credentials for free apple account, user can generate development .p12 and .mobileprovision files to build their project in debug configuration. The implementation is similar to already existing one for cloud build. That is why some common logic is extracted. Naming of some of the items cannot be changed as it will require many follow-up changes that might be a topic for another PR. For consistency request properties are changed to be camel case as they're expected on the server.

http://teampulse.telerik.com/view#item/346464

https://github.com/Icenium/BuilderDaemon/pull/101