### PR TITLE
Replace grunt-lint with tslint

### DIFF
--- a/lib/services/authentication-service.ts
+++ b/lib/services/authentication-service.ts
@@ -35,15 +35,15 @@ export class AuthenticationService implements IAuthenticationService {
 				"/": (request: ServerRequest, response: ServerResponse) => {
 					this.$logger.debug("Login complete: " + request.url);
 					const parsedUrl = parse(request.url, true);
-					const loginResponse = parsedUrl.query.response;
-					if (loginResponse) {
+					const serverResponse = parsedUrl.query.response;
+					if (serverResponse) {
 						response.statusCode = HTTP_STATUS_CODES.FOUND;
 						response.setHeader(HTTP_HEADERS.LOCATION, parsedUrl.query.loginCompleteUrl);
 						this.killLocalhostServer();
 
 						isResolved = true;
 
-						const decodedResponse = new Buffer(loginResponse, "base64").toString();
+						const decodedResponse = new Buffer(serverResponse, "base64").toString();
 						this.rejectLoginPromiseAction = null;
 						authCompleteResolveAction(decodedResponse);
 						response.end();

--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -14,11 +14,11 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 
 	protected get failedError() {
 		return "Build failed.";
-	};
+	}
 
 	protected get failedToStartError() {
 		return "Failed to start cloud build.";
-	};
+	}
 
 	constructor($fs: IFileSystem,
 		$httpClient: Server.IHttpClient,
@@ -510,7 +510,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 			// Ignore the error from getting the server output because the task can finish even if there is error.
 			this.$logger.trace(`Error while getting server logs: ${err}`);
 		}
-	};
+	}
 
 	private async downloadServerResult(buildId: string, buildResult: IServerResult, buildOutputOptions: ICloudServerOutputDirectoryOptions): Promise<string> {
 		this.emitStepChanged(buildId, constants.BUILD_STEP_NAME.DOWNLOAD, constants.BUILD_STEP_PROGRESS.START);

--- a/lib/services/cloud-codesign-service.ts
+++ b/lib/services/cloud-codesign-service.ts
@@ -7,11 +7,11 @@ export class CloudCodesignService extends CloudService implements ICloudCodesign
 
 	protected get failedError() {
 		return "Generation of codesign files failed.";
-	};
+	}
 
 	protected get failedToStartError() {
 		return "Failed to start generation of codesign files.";
-	};
+	}
 
 	constructor($fs: IFileSystem,
 		$httpClient: Server.IHttpClient,

--- a/lib/services/cloud-service.ts
+++ b/lib/services/cloud-service.ts
@@ -92,7 +92,7 @@ export abstract class CloudService extends EventEmitter {
 				url: serverResultObj.fullPath,
 				pipeTo: targetFile
 			});
-		};
+		}
 
 		return targetFileNames;
 	}

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "lib/bootstrap.js",
   "scripts": {
     "test": "node_modules/.bin/istanbul cover node_modules/mocha/bin/_mocha -- --recursive --reporter spec-xunit-file --require test/test-bootstrap.js --timeout 1000 test/",
-    "tslint": "tslint -p tsconfig.json --type-check -e node_modules/**/*",
-    "tslint-fix": "tslint -p tsconfig.json --type-check --fix -e node_modules/**/*"
+    "tslint": "tslint -p tsconfig.json --type-check -e 'node_modules/**/*'",
+    "tslint-fix": "tslint -p tsconfig.json --type-check --fix -e 'node_modules/**/*'"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {
-    "test": "node_modules/.bin/istanbul cover node_modules/mocha/bin/_mocha -- --recursive --reporter spec-xunit-file --require test/test-bootstrap.js --timeout 1000 test/"
+    "test": "node_modules/.bin/istanbul cover node_modules/mocha/bin/_mocha -- --recursive --reporter spec-xunit-file --require test/test-bootstrap.js --timeout 1000 test/",
+    "tslint": "tslint -p tsconfig.json --type-check -e node_modules/**/*",
+    "tslint-fix": "tslint -p tsconfig.json --type-check --fix -e node_modules/**/*"
   },
   "repository": {
     "type": "git",
@@ -19,7 +21,6 @@
   "devDependencies": {
     "@types/chai": "3.4.34",
     "@types/chai-as-promised": "0.0.29",
-    "@types/lodash": "4.14.50",
     "@types/node": "6.0.61",
     "@types/node-forge": "0.6.7",
     "@types/semver": "5.3.30",
@@ -32,17 +33,16 @@
     "grunt-contrib-copy": "1.0.0",
     "grunt-contrib-watch": "1.0.0",
     "grunt-shell": "1.3.0",
-    "grunt-ts": "6.0.0-beta.11",
-    "grunt-tslint": "4.0.1",
+    "grunt-ts": "6.0.0-beta.16",
     "istanbul": "0.4.5",
     "mobile-cli-lib": "https://github.com/telerik/mobile-cli-lib/tarball/master",
-    "mocha": "3.1.2",
-    "mocha-typescript": "^1.0.4",
+    "mocha": "3.5.3",
+    "mocha-typescript": "1.1.8",
     "nativescript": "https://github.com/NativeScript/nativescript-cli/tarball/master",
     "should": "7.0.2",
     "spec-xunit-file": "0.0.1-3",
-    "tslint": "4.3.1",
-    "typescript": "2.1.5"
+    "tslint": "5.7.0",
+    "typescript": "2.4.1"
   },
   "dependencies": {
     "aws4": "1.6.0",


### PR DESCRIPTION
`tslint` has some additional rules and benefits we'd like to use.
* replace `grunt-lint` with `tslint`
* fix lint errors
* introduce `npm` scripts for launching linter

Ping @rosen-vladimirov @TsvetanMilanov @nadyaA 