### PR TITLE
Load $localBuildService lazily

### DIFF
--- a/lib/commands/build-command-helper.ts
+++ b/lib/commands/build-command-helper.ts
@@ -2,13 +2,17 @@ import * as path from "path";
 import { CLOUD_BUILD_CONFIGURATIONS } from "../constants";
 
 export class BuildCommandHelper implements IBuildCommandHelper {
+	private get $localBuildService(): ILocalBuildService {
+		return this.$injector.resolve<ILocalBuildService>("localBuildService");
+	}
+
 	constructor(private $cloudBuildService: ICloudBuildService,
 		private $errors: IErrors,
 		private $logger: ILogger,
 		private $prompter: IPrompter,
 		private $mobileHelper: Mobile.IMobileHelper,
 		private $projectData: IProjectData,
-		private $localBuildService: ILocalBuildService,
+		private $injector: IInjector,
 		private $options: ICloudOptions,
 		private $fs: IFileSystem) {
 		this.$projectData.initializeProjectData();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {


### PR DESCRIPTION
Prefer lazy over eager load so that newer `nativescript-cloud` versions may perform cloud build with older `nativescript` cli versions


Ping @rosen-vladimirov @TsvetanMilanov 
