### PR TITLE
Remove cloud emulator detection

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -49,6 +49,3 @@ $injector.requireCommand(["cloud|codesign", "codesign|cloud"], path.join(__dirna
 $injector.requireCommand("cloud|publish|android", path.join(__dirname, "commands", "cloud-publish"));
 $injector.requireCommand("cloud|publish|ios", path.join(__dirname, "commands", "cloud-publish"));
 $injector.requireCommand("cloud|lib|version", path.join(__dirname, "commands", "cloud-lib-version"));
-
-const $devicesService: Mobile.IDevicesService = $injector.resolve("devicesService");
-$devicesService.addDeviceDiscovery($injector.resolve("cloudEmulatorDeviceDiscovery"));


### PR DESCRIPTION
Whenever a device detection is started, we are starting a server process, which is kept alive even after CLI dies. As we are not using cloud emulators at the moment and as this causes issues when there's no network adapter on Windows, remove these lines for the moment.