### PR TITLE
Add accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -883,6 +883,54 @@ interface IUserService {
 }
 ```
 
+### Module nsCloudAccountsService
+The `nsCloudAccountsService` provides methods for working with accounts. You can call the following methods:
+* `getMyAccounts` method - returns the accounts which the current user can use. Each user will have personal account and shared accounts. Shared accounts are those accounts in which the user is added as developer. </br>
+Definition:
+
+```TypeScript
+/**
+ * Returns all accounts which can be used from the current user.
+ * Each user can have personal account and shared accounts.
+ * @returns {Promise<IAccount[]>}
+ */
+getMyAccounts(): Promise<IAccount[]>
+```
+Detailed description of each parameter can be found [here](./lib/definitions/accounts-service.d.ts).
+</br>
+
+Usage:
+
+```JavaScript
+const tns = require("nativescript");
+
+tns.nsCloudAccountsService.getMyAccounts()
+	.then(accounts => console.log(accounts));
+```
+
+* `getUsageInfo` method - returns the usage information for the provided account. </br>
+Definition:
+
+```TypeScript
+/**
+ * Returns the usage information for the provided account.
+ * @param {string} accountId Account id which will be used to get the usage info.
+ * @returns {Promise<IUsageInfo[]>}.
+ */
+getUsageInfo(accountId: string): Promise<IUsageInfo[]>;
+```
+Detailed description of each parameter can be found [here](./lib/definitions/accounts-service.d.ts).
+</br>
+
+Usage:
+
+```JavaScript
+const tns = require("nativescript");
+
+tns.nsCloudAccountsService.getUsageInfo("d0ce3ac0-36c2-427f-8d27-955915ffe189")
+	.then(usageInfo => console.log(usageInfo));
+```
+
 ### Development
 The project is written in TypeScript. After cloning it, you can set it up by executing the following commands in your terminal:
 * `$ npm i --ignore-scripts` - NOTE: `--ignore-scripts` is a must.

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -19,6 +19,7 @@ $injector.requirePublicClass("nsCloudCodesignService", path.join(__dirname, "ser
 $injector.requirePublicClass("nsCloudEmulatorLauncher", path.join(__dirname, "services", "cloud-emulator-emulator-launcher"));
 $injector.requirePublicClass("nsCloudPublishService", path.join(__dirname, "services", "cloud-publish-service"));
 $injector.requirePublicClass("nsCloudUserService", path.join(__dirname, "services", "user-service"));
+$injector.requirePublicClass("nsCloudAccountsService", path.join(__dirname, "services", "accounts-service"));
 
 // Services.
 $injector.require("nsCloudAuthCloudService", path.join(__dirname, "services", "cloud-services", "auth-cloud-service"));
@@ -27,6 +28,7 @@ $injector.require("nsCloudServicesProxy", path.join(__dirname, "services", "clou
 $injector.require("nsCloudRequestService", path.join(__dirname, "services", "cloud-services", "cloud-request-service"));
 $injector.require("nsCloudEmulatorService", path.join(__dirname, "services", "cloud-services", "cloud-emulator-service"));
 $injector.require("nsCloudCodeCommitService", path.join(__dirname, "services", "cloud-services", "code-commit-service"));
+$injector.require("nsCloudAccountsCloudService", path.join(__dirname, "services", "cloud-services", "accounts-cloud-service"));
 $injector.require("nsCloudPackageInfoService", path.join(__dirname, "services", "package-info-service"));
 $injector.require("nsCloudUploadService", path.join(__dirname, "services", "upload-service"));
 $injector.require("nsCloudGitService", path.join(__dirname, "services", "git-service"));
@@ -49,3 +51,6 @@ $injector.requireCommand(["cloud|codesign", "codesign|cloud"], path.join(__dirna
 $injector.requireCommand("cloud|publish|android", path.join(__dirname, "commands", "cloud-publish"));
 $injector.requireCommand("cloud|publish|ios", path.join(__dirname, "commands", "cloud-publish"));
 $injector.requireCommand("cloud|lib|version", path.join(__dirname, "commands", "cloud-lib-version"));
+
+$injector.requireCommand("account|*list", path.join(__dirname, "commands", "account", "account-list"));
+$injector.requireCommand("account|usage", path.join(__dirname, "commands", "account", "usage"));

--- a/lib/cloud-options-provider.ts
+++ b/lib/cloud-options-provider.ts
@@ -3,6 +3,7 @@ import { DEFAULT_ANDROID_PUBLISH_TRACK } from "./constants";
 export class CloudOptionsProvider implements ICloudOptionsProvider {
 	public get dashedOptions() {
 		return {
+			accountId: { type: OptionType.String },
 			local: { type: OptionType.Boolean },
 			track: { type: OptionType.String, default: DEFAULT_ANDROID_PUBLISH_TRACK }
 		};

--- a/lib/commands/account/account-command-base.ts
+++ b/lib/commands/account/account-command-base.ts
@@ -1,9 +1,9 @@
 export class AccountCommandBase {
 	constructor(private $errors: IErrors,
-		private $userService: IUserService) { }
+		private $nsCloudUserService: IUserService) { }
 
 	public async canExecute(args: string[]): Promise<boolean> {
-		if (!this.$userService.hasUser()) {
+		if (!this.$nsCloudUserService.hasUser()) {
 			this.$errors.failWithoutHelp("You are not logged in.");
 		}
 

--- a/lib/commands/account/account-command-base.ts
+++ b/lib/commands/account/account-command-base.ts
@@ -1,0 +1,12 @@
+export class AccountCommandBase {
+	constructor(private $errors: IErrors,
+		private $userService: IUserService) { }
+
+	public async canExecute(args: string[]): Promise<boolean> {
+		if (!this.$userService.hasUser()) {
+			this.$errors.failWithoutHelp("You are not logged in.");
+		}
+
+		return true;
+	}
+}

--- a/lib/commands/account/account-list.ts
+++ b/lib/commands/account/account-list.ts
@@ -1,0 +1,25 @@
+import { AccountCommandBase } from "./account-command-base";
+import { createTable } from "../../helpers";
+
+export class AccountListCommand extends AccountCommandBase implements ICommand {
+	public allowedParameters: ICommandParameter[] = [];
+
+	constructor($errors: IErrors,
+		$userService: IUserService,
+		private $nsCloudAccountsService: IAccountsService,
+		private $logger: ILogger) {
+		super($errors, $userService);
+	}
+
+	public async execute(args: string[]): Promise<void> {
+		const myAccounts = await this.$nsCloudAccountsService.getMyAccounts();
+		const table = createTable(["#", "Id", "Account", "Type"], myAccounts.map((a, i) => {
+			const index = i + 1;
+			return [index.toString(), a.id, a.name, a.type];
+		}));
+
+		this.$logger.out(table.toString());
+	}
+}
+
+$injector.registerCommand("account|*list", AccountListCommand);

--- a/lib/commands/account/account-list.ts
+++ b/lib/commands/account/account-list.ts
@@ -5,10 +5,10 @@ export class AccountListCommand extends AccountCommandBase implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
 
 	constructor($errors: IErrors,
-		$userService: IUserService,
+		$nsCloudUserService: IUserService,
 		private $nsCloudAccountsService: IAccountsService,
 		private $logger: ILogger) {
-		super($errors, $userService);
+		super($errors, $nsCloudUserService);
 	}
 
 	public async execute(args: string[]): Promise<void> {

--- a/lib/commands/account/account-list.ts
+++ b/lib/commands/account/account-list.ts
@@ -1,5 +1,5 @@
 import { AccountCommandBase } from "./account-command-base";
-import { createTable } from "../../helpers";
+import { createTable, stringifyWithIndentation } from "../../helpers";
 
 export class AccountListCommand extends AccountCommandBase implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
@@ -7,18 +7,27 @@ export class AccountListCommand extends AccountCommandBase implements ICommand {
 	constructor($errors: IErrors,
 		$nsCloudUserService: IUserService,
 		private $nsCloudAccountsService: IAccountsService,
-		private $logger: ILogger) {
+		private $logger: ILogger,
+		private $options: IOptions) {
 		super($errors, $nsCloudUserService);
 	}
 
 	public async execute(args: string[]): Promise<void> {
 		const myAccounts = await this.$nsCloudAccountsService.getMyAccounts();
-		const table = createTable(["#", "Id", "Account", "Type"], myAccounts.map((a, i) => {
-			const index = i + 1;
-			return [index.toString(), a.id, a.name, a.type];
-		}));
+		let output: string;
 
-		this.$logger.out(table.toString());
+		if (this.$options.json) {
+			output = stringifyWithIndentation(myAccounts);
+		} else {
+			const table = createTable(["#", "Id", "Account", "Type"], myAccounts.map((a, i) => {
+				const index = i + 1;
+				return [index.toString(), a.id, a.name, a.type];
+			}));
+
+			output = table.toString();
+		}
+
+		this.$logger.out(output);
 	}
 }
 

--- a/lib/commands/account/usage.ts
+++ b/lib/commands/account/usage.ts
@@ -6,16 +6,16 @@ export class UsageCommand extends AccountCommandBase implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
 
 	public get dashedOptions() {
-		return this.$cloudOptionsProvider.dashedOptions;
+		return this.$nsCloudOptionsProvider.dashedOptions;
 	}
 
 	constructor($errors: IErrors,
-		$userService: IUserService,
+		$nsCloudUserService: IUserService,
 		private $nsCloudAccountsService: IAccountsCloudService,
-		private $cloudOptionsProvider: ICloudOptionsProvider,
+		private $nsCloudOptionsProvider: ICloudOptionsProvider,
 		private $options: ICloudOptions,
 		private $logger: ILogger) {
-		super($errors, $userService);
+		super($errors, $nsCloudUserService);
 	}
 
 	public async execute(args: string[]): Promise<void> {

--- a/lib/commands/account/usage.ts
+++ b/lib/commands/account/usage.ts
@@ -1,6 +1,6 @@
 import { AccountCommandBase } from "./account-command-base";
 import { UNLIMITED } from "../../constants";
-import { createTable } from "../../helpers";
+import { createTable, stringifyWithIndentation } from "../../helpers";
 
 export class UsageCommand extends AccountCommandBase implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
@@ -20,19 +20,27 @@ export class UsageCommand extends AccountCommandBase implements ICommand {
 
 	public async execute(args: string[]): Promise<void> {
 		const usage = await this.$nsCloudAccountsService.getUsageInfo(this.$options.accountId);
-		const table = createTable(["Feature", "Remaining usage"], usage.map(u => {
-			const result = [u.feature];
-			if (u.unlimited) {
-				result.push(UNLIMITED);
-			} else {
-				let remainingUsage = u.allowedUsage - u.usage;
-				result.push(remainingUsage.toString());
-			}
+		let output: string;
 
-			return result;
-		}));
+		if (this.$options.json) {
+			output = stringifyWithIndentation(usage);
+		} else {
+			const table = createTable(["Feature", "Remaining usage"], usage.map(u => {
+				const result = [u.feature];
+				if (u.unlimited) {
+					result.push(UNLIMITED);
+				} else {
+					const remainingUsage = u.allowedUsage - u.usage;
+					result.push(remainingUsage.toString());
+				}
 
-		this.$logger.out(table.toString());
+				return result;
+			}));
+
+			output = table.toString();
+		}
+
+		this.$logger.out(output);
 	}
 }
 

--- a/lib/commands/account/usage.ts
+++ b/lib/commands/account/usage.ts
@@ -1,0 +1,39 @@
+import { AccountCommandBase } from "./account-command-base";
+import { UNLIMITED } from "../../constants";
+import { createTable } from "../../helpers";
+
+export class UsageCommand extends AccountCommandBase implements ICommand {
+	public allowedParameters: ICommandParameter[] = [];
+
+	public get dashedOptions() {
+		return this.$cloudOptionsProvider.dashedOptions;
+	}
+
+	constructor($errors: IErrors,
+		$userService: IUserService,
+		private $nsCloudAccountsService: IAccountsCloudService,
+		private $cloudOptionsProvider: ICloudOptionsProvider,
+		private $options: ICloudOptions,
+		private $logger: ILogger) {
+		super($errors, $userService);
+	}
+
+	public async execute(args: string[]): Promise<void> {
+		const usage = await this.$nsCloudAccountsService.getUsageInfo(this.$options.accountId);
+		const table = createTable(["Feature", "Remaining usage"], usage.map(u => {
+			const result = [u.feature];
+			if (u.unlimited) {
+				result.push(UNLIMITED);
+			} else {
+				let remainingUsage = u.allowedUsage - u.usage;
+				result.push(remainingUsage.toString());
+			}
+
+			return result;
+		}));
+
+		this.$logger.out(table.toString());
+	}
+}
+
+$injector.registerCommand("account|usage", UsageCommand);

--- a/lib/commands/build-command-helper.ts
+++ b/lib/commands/build-command-helper.ts
@@ -89,6 +89,7 @@ export class BuildCommandHelper implements IBuildCommandHelper {
 			buildData.buildConfiguration = CLOUD_BUILD_CONFIGURATIONS.RELEASE;
 			packagePath = (await this.$nsCloudBuildService.build(buildData.projectSettings,
 				buildData.platform, buildData.buildConfiguration,
+				this.$options.accountId,
 				buildData.androidBuildData,
 				buildData.iOSBuildData)).qrData.originalUrl;
 		}

--- a/lib/commands/cloud-build.ts
+++ b/lib/commands/cloud-build.ts
@@ -9,7 +9,6 @@ export class CloudBuild implements ICommand {
 		private $nsCloudBuildCommandHelper: IBuildCommandHelper,
 		private $nsCloudBuildService: ICloudBuildService,
 		private $nsCloudOptionsProvider: ICloudOptionsProvider,
-		private $errors: IErrors,
 		private $options: ICloudOptions,
 		private $projectData: IProjectData) {
 		this.$projectData.initializeProjectData();

--- a/lib/commands/cloud-build.ts
+++ b/lib/commands/cloud-build.ts
@@ -1,10 +1,17 @@
 export class CloudBuild implements ICommand {
 	public allowedParameters: ICommandParameter[];
 
+	public get dashedOptions() {
+		return this.$nsCloudOptionsProvider.dashedOptions;
+	}
+
 	constructor(private $errors: IErrors,
 		private $nsCloudBuildCommandHelper: IBuildCommandHelper,
-		private $projectData: IProjectData,
-		private $nsCloudBuildService: ICloudBuildService) {
+		private $nsCloudBuildService: ICloudBuildService,
+		private $nsCloudOptionsProvider: ICloudOptionsProvider,
+		private $errors: IErrors,
+		private $options: ICloudOptions,
+		private $projectData: IProjectData) {
 		this.$projectData.initializeProjectData();
 	}
 
@@ -12,6 +19,7 @@ export class CloudBuild implements ICommand {
 		const buildData = this.$nsCloudBuildCommandHelper.getCloudBuildData(args[0]);
 		await this.$nsCloudBuildService.build(buildData.projectSettings,
 			buildData.platform, buildData.buildConfiguration,
+			this.$options.accountId,
 			buildData.androidBuildData,
 			buildData.iOSBuildData);
 	}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -23,7 +23,10 @@ export const AUTH_SERVICE_NAME = "auth-service";
 export const BUILD_SERVICE_NAME = "build-service";
 export const EMULATORS_SERVICE_NAME = "emulators-service";
 export const CODE_COMMIT_SERVICE_NAME = "code-commit-service";
+export const MISC_SERVICE_NAME = "misc-service";
+export const ACCOUNTS_SERVICE_NAME = "accounts-service";
 export const DEFAULT_ANDROID_PUBLISH_TRACK = "beta";
+export const UNLIMITED = "unlimited";
 
 export const CLOUD_BUILD_EVENT_NAMES = {
 	BUILD_OUTPUT: "buildOutput",

--- a/lib/definitions/acccounts-service.d.ts
+++ b/lib/definitions/acccounts-service.d.ts
@@ -1,5 +1,24 @@
-interface IAccountsService {
+/**
+ * Describes service which works with accounts.
+ */
+interface IAccountsService extends IGetUsageInfo {
+	/**
+	 * Returns all accounts which can be used from the current user.
+	 * Each user can have personal account and shared accounts.
+	 * @returns {Promise<IAccount[]>}
+	 */
 	getMyAccounts(): Promise<IAccount[]>
-	getUsageInfo(accountId: string): Promise<IUsageInfo[]>;
+
+	/**
+	 * Parses the provided option and uses it to find account.
+	 * The option can be the account id or the number of the account returned from the account list command.
+	 * @param {string} accountIdOption Account id which will be parsed and used to find account.
+	 * @returns {Promise<IAccount>}
+	 */
 	getAccountFromOption(accountIdOption: string): Promise<IAccount>;
+}
+
+interface IFeatureUsage extends IUsageInfoBase {
+	remaining: number;
+	performed: number;
 }

--- a/lib/definitions/acccounts-service.d.ts
+++ b/lib/definitions/acccounts-service.d.ts
@@ -1,0 +1,5 @@
+interface IAccountsService {
+	getMyAccounts(): Promise<IAccount[]>
+	getUsageInfo(accountId: string): Promise<IUsageInfo[]>;
+	getAccountFromOption(accountIdOption: string): Promise<IAccount>;
+}

--- a/lib/definitions/cloud-build-service.d.ts
+++ b/lib/definitions/cloud-build-service.d.ts
@@ -92,12 +92,15 @@ interface ICloudBuildService extends ICloudOperationService {
 	 * @param {IProjectSettings} projectSettings Describes the current project - project dir, application identifier, name and nativescript data.
 	 * @param {string} platform The mobile platform for which the application should be built: Android or iOS.
 	 * @param {string} buildConfiguration The build configuration - Debug or Release.
+	 * @param {string} accountId the account which will be charged for the build.
 	 * @param {IAndroidBuildData} androidBuildData Android specific information for the build.
 	 * @param {IIOSBuildData} iOSBuildData iOS specific information for the build.
 	 * @returns {Promise<IBuildResultData>} Information about the build process. It is returned only on successful build. In case the build fails, the Promise is rejected with the server information.
 	 */
 	build(projectSettings: IProjectSettings,
-		platform: string, buildConfiguration: string,
+		platform: string,
+		buildConfiguration: string,
+		accountId: string,
 		androidBuildData?: IAndroidBuildData,
 		iOSBuildData?: IIOSBuildData): Promise<IBuildResultData>;
 

--- a/lib/definitions/cloud-options.d.ts
+++ b/lib/definitions/cloud-options.d.ts
@@ -2,6 +2,7 @@
  * Describes additional -- flags that can be passed to cloud commands.
  */
 interface ICloudOptions extends IOptions {
+	accountId: string;
 	local: boolean;
 	track: string;
 }

--- a/lib/definitions/cloud-services/accounts-cloud-service.d.ts
+++ b/lib/definitions/cloud-services/accounts-cloud-service.d.ts
@@ -1,6 +1,14 @@
-interface IAccountsCloudService {
-	getAccounts(): Promise<IAccount[]>
+interface IGetUsageInfo {
+	/**
+	 * Returns the usage information for the provided account.
+	 * @param {string} accountId Account id which will be used to get the usage info.
+	 * @returns {Promise<IUsageInfo[]>}.
+	 */
 	getUsageInfo(accountId: string): Promise<IUsageInfo[]>;
+}
+
+interface IAccountsCloudService extends IGetUsageInfo {
+	getAccounts(): Promise<IAccount[]>
 	getUserInfo(): Promise<IUserInfo>;
 }
 
@@ -21,12 +29,24 @@ interface IAccount {
 	type: string;
 }
 
-interface IUsageInfo {
+interface IUsageInfoBase {
 	/**
 	 * The name of the feature (e.g. Cloud Builds).
 	 */
 	feature: string;
 
+	/**
+	 * The maximum allowed usage ammount.
+	 */
+	allowedUsage: number;
+
+	/**
+	 * If this property is set to true the allowed usage is unlimited.
+	 */
+	unlimited: boolean;
+}
+
+interface IUsageInfo extends IUsageInfoBase {
 	/**
 	 * The description of the feature.
 	 */
@@ -41,14 +61,4 @@ interface IUsageInfo {
 	 * The usage ammount after which a notification should be sent to the user.
 	 */
 	softUsageLimit: number;
-
-	/**
-	 * The maximum allowed usage ammount.
-	 */
-	allowedUsage: number;
-
-	/**
-	 * If this property is set to true the allowed usage is unlimited.
-	 */
-	unlimited: boolean;
 }

--- a/lib/definitions/cloud-services/accounts-cloud-service.d.ts
+++ b/lib/definitions/cloud-services/accounts-cloud-service.d.ts
@@ -1,0 +1,54 @@
+interface IAccountsCloudService {
+	getAccounts(): Promise<IAccount[]>
+	getUsageInfo(accountId: string): Promise<IUsageInfo[]>;
+	getUserInfo(): Promise<IUserInfo>;
+}
+
+interface IAccount {
+	/**
+	 * The identifier of the account.
+	 */
+	id: string;
+
+	/**
+	 * The name of the account. Currently firstname and lastname of the owner.
+	 */
+	name: string;
+
+	/**
+	 * The type of the account - personal or shared.
+	 */
+	type: string;
+}
+
+interface IUsageInfo {
+	/**
+	 * The name of the feature (e.g. Cloud Builds).
+	 */
+	feature: string;
+
+	/**
+	 * The description of the feature.
+	 */
+	description: string;
+
+	/**
+	 * The usage amount.
+	 */
+	usage: number;
+
+	/**
+	 * The usage ammount after which a notification should be sent to the user.
+	 */
+	softUsageLimit: number;
+
+	/**
+	 * The maximum allowed usage ammount.
+	 */
+	allowedUsage: number;
+
+	/**
+	 * If this property is set to true the allowed usage is unlimited.
+	 */
+	unlimited: boolean;
+}

--- a/lib/definitions/cloud-services/auth-cloud-service.d.ts
+++ b/lib/definitions/cloud-services/auth-cloud-service.d.ts
@@ -4,7 +4,6 @@ interface IAuthCloudService {
 	refreshToken(refreshToken: string): Promise<ITokenData>;
 	getTokenState(token: string): Promise<ITokenState>;
 	getLogoutUrl(): string;
-	getUserInfo(): Promise<IUserInfo>;
 }
 
 interface ITokenState {

--- a/lib/definitions/cloud-services/build-cloud-service.d.ts
+++ b/lib/definitions/cloud-services/build-cloud-service.d.ts
@@ -22,7 +22,11 @@ interface ICodeSignRequestData extends IBuildId, IAppId, IClean, ICredentials {
 	devices: Mobile.IDeviceInfo[];
 }
 
-interface IBuildRequestData extends IServerRequestData {
+interface IAccountId {
+	accountId: string
+}
+
+interface IBuildRequestData extends IAccountId, IServerRequestData {
 	targets: string[];
 	buildFiles: IBuildFile[];
 }

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -1,7 +1,19 @@
+const Table = require("cli-table");
+
 export function isInteractive(): boolean {
 	return process.stdout.isTTY && process.stdin.isTTY;
 }
 
 export function fromWindowsRelativePathToUnix(windowsRelativePath: string): string {
 	return windowsRelativePath.replace(/\\/g, "/");
+}
+
+export function createTable(headers: string[], data: string[][]): any {
+	const table = new Table({
+		head: headers,
+		chars: { "mid": "", "left-mid": "", "mid-mid": "", "right-mid": "" }
+	});
+
+	_.forEach(data, row => table.push(row));
+	return table;
 }

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -17,3 +17,7 @@ export function createTable(headers: string[], data: string[][]): any {
 	_.forEach(data, row => table.push(row));
 	return table;
 }
+
+export function stringifyWithIndentation(data: any, indentation?: string): string {
+	return JSON.stringify(data, null, indentation || "  ");
+}

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -18,6 +18,6 @@ export function createTable(headers: string[], data: string[][]): any {
 	return table;
 }
 
-export function stringifyWithIndentation(data: any, indentation?: string): string {
+export function stringifyWithIndentation(data: any, indentation?: string | number): string {
 	return JSON.stringify(data, null, indentation || "  ");
 }

--- a/lib/services/accounts-service.ts
+++ b/lib/services/accounts-service.ts
@@ -1,0 +1,39 @@
+export class AccountsService implements IAccountsService {
+	constructor(private $accountsCloudService: IAccountsCloudService,
+		private $errors: IErrors) { }
+
+	public getMyAccounts(): Promise<IAccount[]> {
+		return this.$accountsCloudService.getAccounts();
+	}
+
+	public async getUsageInfo(accountIdOption: string): Promise<IUsageInfo[]> {
+		const account = await this.getAccountFromOption(accountIdOption);
+		return this.$accountsCloudService.getUsageInfo(account.id);
+	}
+
+	public async getAccountFromOption(accountIdOption: string): Promise<IAccount> {
+		const accounts = await this.getMyAccounts();
+		if (!accountIdOption) {
+			this.$errors.failWithoutHelp("Please provide accountId.");
+		} else {
+			let selectedAccount = _.find(accounts, a => a.id === accountIdOption);
+			if (selectedAccount) {
+				return selectedAccount;
+			} else {
+				try {
+					const accountIndex = Number.parseInt(accountIdOption);
+					selectedAccount = accounts[accountIndex - 1];
+					if (selectedAccount) {
+						return selectedAccount;
+					} else {
+						this.$errors.failWithoutHelp("Invalid accountId index provided.");
+					}
+				} catch (err) {
+					this.$errors.failWithoutHelp("Invalid accountId option provided.");
+				}
+			}
+		}
+	}
+}
+
+$injector.register("accountsService", AccountsService);

--- a/lib/services/accounts-service.ts
+++ b/lib/services/accounts-service.ts
@@ -15,23 +15,19 @@ export class AccountsService implements IAccountsService {
 		const accounts = await this.getMyAccounts();
 		if (!accountIdOption) {
 			this.$errors.failWithoutHelp("Please provide accountId.");
+		}
+
+		let selectedAccount = _.find(accounts, a => a.id === accountIdOption);
+		if (selectedAccount) {
+			return selectedAccount;
 		} else {
-			let selectedAccount = _.find(accounts, a => a.id === accountIdOption);
-			if (selectedAccount) {
-				return selectedAccount;
-			} else {
-				try {
-					const accountIndex = Number.parseInt(accountIdOption);
-					selectedAccount = accounts[accountIndex - 1];
-					if (selectedAccount) {
-						return selectedAccount;
-					} else {
-						this.$errors.failWithoutHelp("Invalid accountId index provided.");
-					}
-				} catch (err) {
-					this.$errors.failWithoutHelp("Invalid accountId option provided.");
-				}
+			const accountIndex = Number.parseInt(accountIdOption);
+			selectedAccount = accounts[accountIndex - 1];
+			if (!selectedAccount) {
+				this.$errors.failWithoutHelp("Invalid accountId index provided.");
 			}
+
+			return selectedAccount;
 		}
 	}
 }

--- a/lib/services/accounts-service.ts
+++ b/lib/services/accounts-service.ts
@@ -1,14 +1,14 @@
 export class AccountsService implements IAccountsService {
-	constructor(private $accountsCloudService: IAccountsCloudService,
+	constructor(private $nsCloudAccountsCloudService: IAccountsCloudService,
 		private $errors: IErrors) { }
 
 	public getMyAccounts(): Promise<IAccount[]> {
-		return this.$accountsCloudService.getAccounts();
+		return this.$nsCloudAccountsCloudService.getAccounts();
 	}
 
 	public async getUsageInfo(accountIdOption: string): Promise<IUsageInfo[]> {
 		const account = await this.getAccountFromOption(accountIdOption);
-		return this.$accountsCloudService.getUsageInfo(account.id);
+		return this.$nsCloudAccountsCloudService.getUsageInfo(account.id);
 	}
 
 	public async getAccountFromOption(accountIdOption: string): Promise<IAccount> {
@@ -36,4 +36,4 @@ export class AccountsService implements IAccountsService {
 	}
 }
 
-$injector.register("accountsService", AccountsService);
+$injector.register("nsCloudAccountsService", AccountsService);

--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -23,19 +23,19 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 	constructor($fs: IFileSystem,
 		$httpClient: Server.IHttpClient,
 		$logger: ILogger,
+		private $errors: IErrors,
+		private $mobileHelper: Mobile.IMobileHelper,
 		private $nsCloudAccountsService: IAccountsService,
 		private $nsCloudBuildCloudService: IBuildCloudService,
-		private $nsCloudGitService: IGitService,
-		private $errors: IErrors,
-		private $nsCloudItmsServicesPlistHelper: IItmsServicesPlistHelper,
-		private $platformService: IPlatformService,
 		private $nsCloudBuildOutputFilter: ICloudBuildOutputFilter,
-		private $mobileHelper: Mobile.IMobileHelper,
+		private $nsCloudGitService: IGitService,
+		private $nsCloudItmsServicesPlistHelper: IItmsServicesPlistHelper,
+		private $nsCloudUploadService: IUploadService,
+		private $nsCloudUserService: IUserService,
+		private $platformService: IPlatformService,
 		private $projectHelper: IProjectHelper,
 		private $projectDataService: IProjectDataService,
-		private $qr: IQrCodeGenerator,
-		private $nsCloudUploadService: IUploadService,
-		private $nsCloudUserService: IUserService) {
+		private $qr: IQrCodeGenerator) {
 		super($fs, $httpClient, $logger);
 	}
 
@@ -62,7 +62,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		androidBuildData?: IAndroidBuildData,
 		iOSBuildData?: IIOSBuildData): Promise<IBuildResultData> {
 		const buildId = uuid.v4();
-		const account = await this.$accountsService.getAccountFromOption(accountId);
+		const account = await this.$nsCloudAccountsService.getAccountFromOption(accountId);
 		try {
 			const buildResult = await this.executeBuild(projectSettings, platform, buildConfiguration, buildId, account.id, androidBuildData, iOSBuildData);
 			return buildResult;

--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -23,6 +23,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 	constructor($fs: IFileSystem,
 		$httpClient: Server.IHttpClient,
 		$logger: ILogger,
+		private $nsCloudAccountsService: IAccountsService,
 		private $nsCloudBuildCloudService: IBuildCloudService,
 		private $nsCloudGitService: IGitService,
 		private $errors: IErrors,
@@ -57,12 +58,13 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 	public async build(projectSettings: IProjectSettings,
 		platform: string,
 		buildConfiguration: string,
+		accountId: string,
 		androidBuildData?: IAndroidBuildData,
 		iOSBuildData?: IIOSBuildData): Promise<IBuildResultData> {
 		const buildId = uuid.v4();
-
+		const account = await this.$accountsService.getAccountFromOption(accountId);
 		try {
-			const buildResult = await this.executeBuild(projectSettings, platform, buildConfiguration, buildId, androidBuildData, iOSBuildData);
+			const buildResult = await this.executeBuild(projectSettings, platform, buildConfiguration, buildId, account.id, androidBuildData, iOSBuildData);
 			return buildResult;
 		} catch (err) {
 			err.buildId = buildId;
@@ -74,6 +76,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		platform: string,
 		buildConfiguration: string,
 		buildId: string,
+		accountId: string,
 		androidBuildData?: IAndroidBuildData,
 		iOSBuildData?: IIOSBuildData): Promise<IBuildResultData> {
 		const buildInformationString = `cloud build of '${projectSettings.projectDir}', platform: '${platform}', ` +
@@ -107,7 +110,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		const buildCredentials = await this.$nsCloudBuildCloudService.getBuildCredentials({ appId: projectSettings.projectId, fileNames: fileNames });
 
 		const filesToUpload = this.prepareFilesToUpload(buildCredentials.urls, buildFiles);
-		let buildProps = await this.prepareBuildRequest(buildId, projectSettings, platform, buildConfiguration, buildCredentials, filesToUpload);
+		let buildProps = await this.prepareBuildRequest(buildId, projectSettings, platform, buildConfiguration, buildCredentials, filesToUpload, accountId);
 		if (this.$mobileHelper.isAndroidPlatform(platform)) {
 			buildProps = await this.getAndroidBuildProperties(projectSettings, buildProps, filesToUpload, androidBuildData);
 		} else if (this.$mobileHelper.isiOSPlatform(platform)) {
@@ -302,7 +305,8 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		platform: string,
 		buildConfiguration: string,
 		buildCredentials: IBuildCredentialResponse,
-		filesToUpload: IAmazonStorageEntryData[]): Promise<IBuildRequestData> {
+		filesToUpload: IAmazonStorageEntryData[],
+		accountId: string): Promise<IBuildRequestData> {
 		this.emitStepChanged(buildId, constants.BUILD_STEP_NAME.UPLOAD, constants.BUILD_STEP_PROGRESS.START);
 		let buildFiles;
 		try {
@@ -349,6 +353,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		 * behavior in the tooling.
 		 */
 		return {
+			accountId,
 			properties: {
 				buildId,
 				buildConfiguration: buildConfiguration,

--- a/lib/services/cloud-services/accounts-cloud-service.ts
+++ b/lib/services/cloud-services/accounts-cloud-service.ts
@@ -1,0 +1,24 @@
+import { ACCOUNTS_SERVICE_NAME, HTTP_METHODS } from "../../constants";
+import { CloudServiceBase } from "./cloud-service-base";
+
+export class AccountsCloudService extends CloudServiceBase implements IAccountsCloudService {
+	protected serviceName: string = ACCOUNTS_SERVICE_NAME;
+
+	constructor(protected $cloudServicesProxy: ICloudServicesProxy) {
+		super($cloudServicesProxy);
+	}
+
+	public getAccounts(): Promise<IAccount[]> {
+		return this.sendRequest<IAccount[]>(HTTP_METHODS.GET, "api/accounts", null);
+	}
+
+	public getUsageInfo(accountId: string): Promise<IUsageInfo[]> {
+		return this.sendRequest<IUsageInfo[]>(HTTP_METHODS.GET, `api/usage?accountId=${accountId}`, null);
+	}
+
+	public getUserInfo(): Promise<IUserInfo> {
+		return this.sendRequest<IUserInfo>(HTTP_METHODS.GET, "api/user-info", null);
+	}
+}
+
+$injector.register("accountsCloudService", AccountsCloudService);

--- a/lib/services/cloud-services/accounts-cloud-service.ts
+++ b/lib/services/cloud-services/accounts-cloud-service.ts
@@ -4,8 +4,8 @@ import { CloudServiceBase } from "./cloud-service-base";
 export class AccountsCloudService extends CloudServiceBase implements IAccountsCloudService {
 	protected serviceName: string = ACCOUNTS_SERVICE_NAME;
 
-	constructor(protected $cloudServicesProxy: ICloudServicesProxy) {
-		super($cloudServicesProxy);
+	constructor(protected $nsCloudServicesProxy: ICloudServicesProxy) {
+		super($nsCloudServicesProxy);
 	}
 
 	public getAccounts(): Promise<IAccount[]> {
@@ -21,4 +21,4 @@ export class AccountsCloudService extends CloudServiceBase implements IAccountsC
 	}
 }
 
-$injector.register("accountsCloudService", AccountsCloudService);
+$injector.register("nsCloudAccountsCloudService", AccountsCloudService);

--- a/lib/services/cloud-services/auth-cloud-service.ts
+++ b/lib/services/cloud-services/auth-cloud-service.ts
@@ -29,10 +29,6 @@ export class AuthCloudService extends CloudServiceBase implements IAuthCloudServ
 		return this.getAuthUrl("api/logout");
 	}
 
-	public getUserInfo(): Promise<IUserInfo> {
-		return this.sendRequest<IUserInfo>(HTTP_METHODS.GET, "api/user-info", null);
-	}
-
 	private getAuthUrl(urlPath: string): string {
 		const proto = this.$nsCloudServicesProxy.getServiceProto(AUTH_SERVICE_NAME);
 		const host = this.$nsCloudServicesProxy.getServiceAddress(AUTH_SERVICE_NAME);

--- a/lib/services/user-service.ts
+++ b/lib/services/user-service.ts
@@ -5,8 +5,8 @@ export class UserService implements IUserService {
 	private userData: IUserData;
 	private userInfoDirectory: string;
 
-	private get $nsCloudAuthCloudService(): IAuthCloudService {
-		return this.$injector.resolve("nsCloudAuthCloudService");
+	private get $nsCloudAccountsService(): IAccountsCloudService {
+		return this.$injector.resolve("nsCloudAccountsService");
 	}
 
 	constructor(private $injector: IInjector,
@@ -78,7 +78,7 @@ export class UserService implements IUserService {
 			return null;
 		}
 
-		const userInfo = await this.$nsCloudAuthCloudService.getUserInfo();
+		const userInfo = await this.$nsCloudAccountsService.getUserInfo();
 		return userInfo.externalAvatarUrl;
 	}
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "aws4": "1.6.0",
+    "cli-table": "https://github.com/telerik/cli-table/tarball/v0.3.1.2",
     "cloud-device-emulator": "0.5.0",
     "cookie": "0.3.1",
     "lodash": "4.17.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {

--- a/server-configs/config-base.json
+++ b/server-configs/config-base.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": "v1",
+	"apiVersion": "v2",
 	"domainName": "digitalfactory.rocks",
 	"serverProto": "https"
 }

--- a/server-configs/config-dev.json
+++ b/server-configs/config-dev.json
@@ -12,6 +12,12 @@
 		},
 		"code-commit-service": {
 			"subdomain": "code-commit"
+		},
+		"misc-service": {
+			"subdomain": "dev-misc"
+		},
+		"accounts-service": {
+			"subdomain": "dev-accounts"
 		}
 	}
 }

--- a/server-configs/config-local.json
+++ b/server-configs/config-local.json
@@ -11,6 +11,9 @@
 		"emulators-service": {
 			"fullHostName": "localhost:8002"
 		},
+		"code-commit-service": {
+			"subdomain": "localhost:8003"
+		},
 		"misc-service": {
 			"fullHostName": "localhost:8004"
 		},

--- a/server-configs/config-local.json
+++ b/server-configs/config-local.json
@@ -11,8 +11,11 @@
 		"emulators-service": {
 			"fullHostName": "localhost:8002"
 		},
-		"code-commit-service": {
-			"fullHostName": "localhost:8003"
+		"misc-service": {
+			"fullHostName": "localhost:8004"
+		},
+		"accounts-service": {
+			"fullHostName": "localhost:8005"
 		}
 	}
 }

--- a/server-configs/config-local.json
+++ b/server-configs/config-local.json
@@ -12,7 +12,7 @@
 			"fullHostName": "localhost:8002"
 		},
 		"code-commit-service": {
-			"subdomain": "localhost:8003"
+			"fullHostName": "localhost:8003"
 		},
 		"misc-service": {
 			"fullHostName": "localhost:8004"

--- a/server-configs/config-production.json
+++ b/server-configs/config-production.json
@@ -12,6 +12,12 @@
 		},
 		"code-commit-service": {
 			"subdomain": "code-commit"
+		},
+		"misc-service": {
+			"subdomain": "misc"
+		},
+		"accounts-service": {
+			"subdomain": "accounts"
 		}
 	}
 }

--- a/server-configs/config-test.json
+++ b/server-configs/config-test.json
@@ -12,6 +12,12 @@
 		},
 		"code-commit-service": {
 			"subdomain": "test-code-commit"
+		},
+		"misc-service": {
+			"subdomain": "test-misc"
+		},
+		"accounts-service": {
+			"subdomain": "test-accounts"
 		}
 	}
 }

--- a/server-configs/config.json
+++ b/server-configs/config.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": "v1",
+	"apiVersion": "v2",
 	"domainName": "digitalfactory.rocks",
 	"serverProto": "https",
 	"stage": "production",

--- a/server-configs/config.json
+++ b/server-configs/config.json
@@ -15,6 +15,12 @@
 		},
 		"code-commit-service": {
 			"subdomain": "code-commit"
+		},
+		"misc-service": {
+			"subdomain": "misc"
+		},
+		"accounts-service": {
+			"subdomain": "accounts"
 		}
 	}
 }


### PR DESCRIPTION
Some of the cloud functionality will become paid. This requires the account abstraction.
Currently we have users and we use them in our cloud services. Now we are going to use the users as part of accounts. Each user has personal account. Also the user A can add to his/hers account the user B. This way the user B will be able to  use the subscriptions of the user A. 

This PR adds the following commands:
- `tns account` (`tns account list`) -> this command show all accounts of the current user.
- `tns account usage` -> this command show the remaining usage for each feature from the subscription of the provided account.

Added services to the public API:
- `accountsService`

### Breaking changes:
- `cloudBuildService.build` requires accountId.