### PR TITLE
Rename all services names

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This section describes all methods that can be invoked when you have installed t
 const tns = require("nativescript");
 ```
 
-### Module cloudBuildService
-The `cloudBuildService` allows build of applications in the cloud. You can call the following methods:
+### Module nsCloudBuildService
+The `nsCloudBuildService` allows build of applications in the cloud. You can call the following methods:
 * `build` method - it validates passed arguments and tries to build the application in the cloud. In case of successful build, the build result (.apk, .ipa or .zip) is downloaded. The result contains information about the whole build process, path to the downloaded build result and information used to generate a QR code, pointing to the latest build result (in S3). </br>
 Definition:
 
@@ -84,7 +84,7 @@ const androidReleaseConfigurationData = {
 const platform = "android";
 const buildConfiguration = "release";
 
-tns.cloudBuildService.on("buildOutput", (data) => {
+tns.nsCloudBuildService.on("buildOutput", (data) => {
 	console.log(data);
 	/*
 		Sample data object:
@@ -96,7 +96,7 @@ tns.cloudBuildService.on("buildOutput", (data) => {
 	*/
 });
 
-tns.cloudBuildService.on("stepChanged", (data) => {
+tns.nsCloudBuildService.on("stepChanged", (data) => {
 	console.log(data);
 	/*
 		Sample data object:
@@ -108,7 +108,7 @@ tns.cloudBuildService.on("stepChanged", (data) => {
 	*/
 });
 
-tns.cloudBuildService
+tns.nsCloudBuildService
 	.build(projectSettings, platform, buildConfiguration, androidReleaseConfigurationData)
 	.then(buildResult => console.log(buildResult))
 	.catch(err => console.error(err));
@@ -154,7 +154,7 @@ const androidReleaseConfigurationData = {
 const platform = "android";
 const buildConfiguration = "release";
 
-tns.cloudBuildService
+tns.nsCloudBuildService
 	.validateBuildProperties(platform, buildConfiguration, projectId, androidReleaseConfigurationData)
 	.then(buildResult => console.log("Data is valid"))
 	.catch(err => console.error("Data is invalid:", err));
@@ -179,7 +179,7 @@ Detailed description of the parameter can be found [here](./lib/definitions/clou
 Usage:
 ```JavaScript
 const tns = require("nativescript");
-const cloudBuildOutputDirectory = tns.cloudBuildService
+const cloudBuildOutputDirectory = tns.nsCloudBuildService
 			.getBuildOutputDirectory({
 				platform: "ios",
 				projectDir: "/tmp/myProject"
@@ -187,8 +187,8 @@ const cloudBuildOutputDirectory = tns.cloudBuildService
 			});
 ```
 
-### Module cloudCodesignService
-The `cloudCodesignService` allows generation of codesign files (currently only iOS .p12 and .mobileprovision) in the cloud. You can call the following methods:
+### Module nsCloudCodesignService
+The `nsCloudCodesignService` allows generation of codesign files (currently only iOS .p12 and .mobileprovision) in the cloud. You can call the following methods:
 * `generateCodesignFiles` method - it validates passed arguments and tries to generate codesign files in the cloud. In case of success, the result files (.p12 and/or .mobileprovision) are downloaded. The result contains information about errors, if any, and path to the downloaded codesign files (in S3). </br>
 Definition:
 
@@ -206,7 +206,7 @@ Detailed description of the parameter can be found [here](./lib/definitions/clou
 Usage:
 ```JavaScript
 const tns = require("nativescript");
-const codesignResultData = tns.cloudBuildService
+const codesignResultData = tns.nsCloudBuildService
 			.generateCodesignFiles({
 				username:'appleuser@mail.com',
 				password:'password',
@@ -235,7 +235,7 @@ Detailed description of the parameter can be found [here](./lib/definitions/clou
 Usage:
 ```JavaScript
 const tns = require("nativescript");
-const generateCodesignFilesOutputDirectory = tns.cloudBuildService
+const generateCodesignFilesOutputDirectory = tns.nsCloudBuildService
 				.getServerOperationOutputDirectory({
 					platform: "ios",
 					projectDir: "/tmp/myProject"
@@ -243,8 +243,8 @@ const generateCodesignFilesOutputDirectory = tns.cloudBuildService
 				});
 ```
 
-### Module cloudPublishService
-The `cloudPublishService` allows publishing build packages to an application store (either GooglePlay or iTunesConnect). You can call the following methods:
+### Module nsCloudPublishService
+The `nsCloudPublishService` allows publishing build packages to an application store (either GooglePlay or iTunesConnect). You can call the following methods:
 * `publishToItunesConnect` method - it will try to publish the provided package to iTunes Connect. </br>
 Definition:
 
@@ -261,7 +261,7 @@ Detailed description of the parameter can be found [here](./lib/definitions/clou
 Usage:
 ```JavaScript
 const tns = require("nativescript");
-tns.cloudPublishService
+tns.nsCloudPublishService
 	.publishToItunesConnect({
 		credentials: {
 			username: "user",
@@ -292,7 +292,7 @@ Detailed description of the parameter can be found [here](./lib/definitions/clou
 Usage:
 ```JavaScript
 const tns = require("nativescript");
-tns.cloudPublishService
+tns.nsCloudPublishService
 	.publishToGooglePlay({
 		track: "alpha",
 		pathToAuthJson: "/tmp/myAuthJson.json",
@@ -305,8 +305,8 @@ tns.cloudPublishService
 	.catch(err => console.error(err));
 ```
 
-### Module applicationService
-The `applicationService` allows for application management and gathering more information about the app's current state. You can call the following methods:
+### Module nsCloudApplicationService
+The `nsCloudApplicationService` allows for application management and gathering more information about the app's current state. You can call the following methods:
 * `shouldBuild` method - it will determine whether the current application should be built or not. </br>
 Definition:
 
@@ -323,7 +323,7 @@ Detailed description of the parameter can be found [here](./lib/definitions/appl
 Usage:
 ```JavaScript
 const tns = require("nativescript");
-tns.cloudPublishService
+tns.nsCloudApplicationService
 	.shouldBuild({
 		projectDir: "/tmp/myProject",
 		platform: "android",
@@ -351,7 +351,7 @@ Detailed description of the parameter can be found [here](./lib/definitions/appl
 Usage:
 ```JavaScript
 const tns = require("nativescript");
-tns.cloudPublishService
+tns.nsCloudPublishService
 	.shouldInstall({
 		projectDir: "/tmp/myProject",
 		deviceIdentifier: "192.168.56.101:5555",
@@ -363,8 +363,8 @@ tns.cloudPublishService
 	.catch(err => console.error(err));
 ```
 
-### Module cloudEmulatorLauncher
-The `cloudEmulatorLauncher` provides a way for initial interaction with cloud emulators. You can call the following methods:
+### Module nsCloudEmulatorLauncher
+The `nsCloudEmulatorLauncher` provides a way for initial interaction with cloud emulators. You can call the following methods:
 * `startEmulator` method - starts an cloud emulator and returns a url where an html page is located, containing an iframe with the actual emulator. </br>
 Definition:
 
@@ -405,7 +405,7 @@ Usage:
 ```JavaScript
 const tns = require("nativescript");
 
-tns.cloudEmulatorLauncher.startEmulator({
+tns.nsCloudEmulatorLauncher.startEmulator({
 			packageFile: "test.apk",
 			platform: "android",
 			model: "nexus5"
@@ -415,8 +415,8 @@ tns.cloudEmulatorLauncher.startEmulator({
 		});
 ```
 
-### Module authenticationService
-The `authenticationService` is used for authentication related operations (login, logout etc.). You can call the following methods </br>
+### Module nsCloudAuthenticationService
+The `nsCloudAuthenticationService` is used for authentication related operations (login, logout etc.). You can call the following methods </br>
 * `login` - Starts localhost server on which the login response will be returned. After that if there is `options.openAction` it will be used to open the login url. If this option is not defined the default opener will be used. After successful login returns the user information.
 </br>
 Definition:
@@ -436,7 +436,7 @@ Usage:
 ```JavaScript
 const tns = require("nativescript");
 
-tns.authenticationService
+tns.nsCloudAuthenticationService
 	.login()
 	.then(userInfo => console.log(userInfo))
 	.catch(err => console.error(err));
@@ -453,7 +453,7 @@ const openAction = url => {
 };
 const loginOptions = { openAction: openAction };
 
-tns.authenticationService
+tns.nsCloudAuthenticationService
 	.login(loginOptions)
 	.then(userInfo => console.log(userInfo))
 	.catch(err => console.error(err));
@@ -478,7 +478,7 @@ Usage:
 ```JavaScript
 const tns = require("nativescript");
 
-tns.authenticationService.logout();
+tns.nsCloudAuthenticationService.logout();
 ```
 
 ```JavaScript
@@ -492,7 +492,7 @@ const openAction = url => {
 };
 const logoutOptions = { openAction: openAction };
 
-tns.authenticationService.logout(logoutOptions);
+tns.nsCloudAuthenticationService.logout(logoutOptions);
 ```
 
 * `isUserLoggedIn` - Checks if the access token of the current user is valid. If it is - the method will return true. If it isn't - the method will try to issue new access token. If the method can't issue new token it will return false.
@@ -513,7 +513,7 @@ Usage:
 ```JavaScript
 const tns = require("nativescript");
 
-tns.authenticationService
+tns.nsCloudAuthenticationService
 	.isUserLoggedIn()
 	.then(isLoggedIn => console.log(isLoggedIn))
 	.catch(err => console.error(err));
@@ -536,7 +536,7 @@ Usage:
 ```JavaScript
 const tns = require("nativescript");
 
-tns.authenticationService.refreshCurrentUserToken()
+tns.nsCloudAuthenticationService.refreshCurrentUserToken()
 	.then(() => console.log("Success"))
 	.catch(err => console.error(err));
 ```
@@ -559,12 +559,12 @@ Usage:
 ```JavaScript
 const tns = require("nativescript");
 
-tns.authenticationService
+tns.nsCloudAuthenticationService
 	.login()
 	.then(userInfo => console.log(userInfo))
 	.catch(err => console.error(err));
 
-tns.authenticationService.cancelLogin();
+tns.nsCloudAuthenticationService.cancelLogin();
 ```
 
 #### Interfaces:
@@ -646,8 +646,8 @@ interface ITokenState {
 }
 ```
 
-### Module userService
-The `userService` is used to get information aboud the current user or modify it. You can call the following methods </br>
+### Module nsCloudUserService
+The `nsCloudUserService` is used to get information aboud the current user or modify it. You can call the following methods </br>
 * `hasUser` - Checks if there is user information.
 </br>
 Definition:
@@ -665,7 +665,7 @@ Usage:
 ```JavaScript
 const tns = require("nativescript");
 
-const hasUser = tns.userService.hasUser();
+const hasUser = tns.nsCloudUserService.hasUser();
 console.log(hasUser);
 ```
 
@@ -686,7 +686,7 @@ Usage:
 ```JavaScript
 const tns = require("nativescript");
 
-const user = tns.userService.getUser();
+const user = tns.nsCloudUserService.getUser();
 console.log(user);
 ```
 
@@ -717,7 +717,7 @@ Usage:
 ```JavaScript
 const tns = require("nativescript");
 
-const userData = tns.userService.getUserData();
+const userData = tns.nsCloudUserService.getUserData();
 console.log(userData);
 ```
 
@@ -764,7 +764,7 @@ const userData = {
 	}
 };
 
-tns.userService.setUserData(userData);
+tns.nsCloudUserService.setUserData(userData);
 ```
 
 * `setToken` - Sets only the token of the current user.
@@ -791,7 +791,7 @@ const token = {
 	accessToken: "some token"
 };
 
-tns.userService.setToken(token);
+tns.nsCloudUserService.setToken(token);
 ```
 
 * `clearUserData` - Removes the current user data.
@@ -811,7 +811,7 @@ Usage:
 ```JavaScript
 const tns = require("nativescript");
 
-tns.userService.clearUserData();
+tns.nsCloudUserService.clearUserData();
 ```
 
 * `getUserAvatar` - Return the URL where the avatar picture can be downloaded from.
@@ -831,7 +831,7 @@ Usage:
 ```JavaScript
 const tns = require("nativescript");
 
-tns.userService.hasUser()
+tns.nsCloudUserService.hasUser()
 	.then(userAvatar => console.log(userAvatar));
 ```
 

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -1,35 +1,35 @@
 import * as path from "path";
 
-$injector.require("httpServer", path.join(__dirname, "http-server"));
-$injector.require("itmsServicesPlistHelper", path.join(__dirname, "itms-services-plist-helper"));
-$injector.require("serverConfigManager", path.join(__dirname, "server-config-manager"));
-$injector.require("cloudBuildOutputFilter", path.join(__dirname, "cloud-build-output-filter"));
-$injector.require("cloudDeviceEmulator", path.join(__dirname, "cloud-device-emulator"));
-$injector.require("cloudOptionsProvider", path.join(__dirname, "cloud-options-provider"));
-$injector.require("buildCommandHelper", path.join(__dirname, "commands", "build-command-helper"));
+$injector.require("nsCloudHttpServer", path.join(__dirname, "http-server"));
+$injector.require("nsCloudItmsServicesPlistHelper", path.join(__dirname, "itms-services-plist-helper"));
+$injector.require("nsCloudServerConfigManager", path.join(__dirname, "server-config-manager"));
+$injector.require("nsCloudBuildOutputFilter", path.join(__dirname, "cloud-build-output-filter"));
+$injector.require("nsCloudDeviceEmulator", path.join(__dirname, "cloud-device-emulator"));
+$injector.require("nsCloudOptionsProvider", path.join(__dirname, "cloud-options-provider"));
+$injector.require("nsCloudBuildCommandHelper", path.join(__dirname, "commands", "build-command-helper"));
 
 // Mobile.
-$injector.require("cloudEmulatorDeviceDiscovery", path.join(__dirname, "mobile", "mobile-core", "cloud-emulator-device-discovery"));
+$injector.require("nsCloudEmulatorDeviceDiscovery", path.join(__dirname, "mobile", "mobile-core", "cloud-emulator-device-discovery"));
 
 // Public API.
-$injector.requirePublicClass("applicationService", path.join(__dirname, "services", "application-service"));
-$injector.requirePublicClass("authenticationService", path.join(__dirname, "services", "authentication-service"));
-$injector.requirePublicClass("cloudBuildService", path.join(__dirname, "services", "cloud-build-service"));
-$injector.requirePublicClass("cloudCodesignService", path.join(__dirname, "services", "cloud-codesign-service"));
-$injector.requirePublicClass("cloudEmulatorLauncher", path.join(__dirname, "services", "cloud-emulator-emulator-launcher"));
-$injector.requirePublicClass("cloudPublishService", path.join(__dirname, "services", "cloud-publish-service"));
-$injector.requirePublicClass("userService", path.join(__dirname, "services", "user-service"));
+$injector.requirePublicClass("nsCloudApplicationService", path.join(__dirname, "services", "application-service"));
+$injector.requirePublicClass("nsCloudAuthenticationService", path.join(__dirname, "services", "authentication-service"));
+$injector.requirePublicClass("nsCloudBuildService", path.join(__dirname, "services", "cloud-build-service"));
+$injector.requirePublicClass("nsCloudCodesignService", path.join(__dirname, "services", "cloud-codesign-service"));
+$injector.requirePublicClass("nsCloudEmulatorLauncher", path.join(__dirname, "services", "cloud-emulator-emulator-launcher"));
+$injector.requirePublicClass("nsCloudPublishService", path.join(__dirname, "services", "cloud-publish-service"));
+$injector.requirePublicClass("nsCloudUserService", path.join(__dirname, "services", "user-service"));
 
 // Services.
-$injector.require("authCloudService", path.join(__dirname, "services", "cloud-services", "auth-cloud-service"));
-$injector.require("buildCloudService", path.join(__dirname, "services", "cloud-services", "build-cloud-service"));
-$injector.require("cloudServicesProxy", path.join(__dirname, "services", "cloud-services", "cloud-services-proxy"));
-$injector.require("cloudRequestService", path.join(__dirname, "services", "cloud-services", "cloud-request-service"));
-$injector.require("cloudEmulatorService", path.join(__dirname, "services", "cloud-services", "cloud-emulator-service"));
-$injector.require("codeCommitService", path.join(__dirname, "services", "cloud-services", "code-commit-service"));
-$injector.require("packageInfoService", path.join(__dirname, "services", "package-info-service"));
-$injector.require("uploadService", path.join(__dirname, "services", "upload-service"));
-$injector.require("gitService", path.join(__dirname, "services", "git-service"));
+$injector.require("nsCloudAuthCloudService", path.join(__dirname, "services", "cloud-services", "auth-cloud-service"));
+$injector.require("nsCloudBuildCloudService", path.join(__dirname, "services", "cloud-services", "build-cloud-service"));
+$injector.require("nsCloudServicesProxy", path.join(__dirname, "services", "cloud-services", "cloud-services-proxy"));
+$injector.require("nsCloudRequestService", path.join(__dirname, "services", "cloud-services", "cloud-request-service"));
+$injector.require("nsCloudEmulatorService", path.join(__dirname, "services", "cloud-services", "cloud-emulator-service"));
+$injector.require("nsCloudCodeCommitService", path.join(__dirname, "services", "cloud-services", "code-commit-service"));
+$injector.require("nsCloudPackageInfoService", path.join(__dirname, "services", "package-info-service"));
+$injector.require("nsCloudUploadService", path.join(__dirname, "services", "upload-service"));
+$injector.require("nsCloudGitService", path.join(__dirname, "services", "git-service"));
 
 // Commands.
 $injector.requireCommand("config|*get", path.join(__dirname, "commands", "config", "config-get"));

--- a/lib/cloud-build-output-filter.ts
+++ b/lib/cloud-build-output-filter.ts
@@ -24,4 +24,4 @@ export class CloudBuildOutputFilter implements ICloudBuildOutputFilter {
 	}
 }
 
-$injector.register("cloudBuildOutputFilter", CloudBuildOutputFilter);
+$injector.register("nsCloudBuildOutputFilter", CloudBuildOutputFilter);

--- a/lib/cloud-device-emulator.ts
+++ b/lib/cloud-device-emulator.ts
@@ -40,4 +40,4 @@ export class CloudDeviceEmulatorWrapper implements ICloudDeviceEmulator {
 	}
 }
 
-$injector.register("cloudDeviceEmulator", CloudDeviceEmulatorWrapper);
+$injector.register("nsCloudDeviceEmulator", CloudDeviceEmulatorWrapper);

--- a/lib/cloud-options-provider.ts
+++ b/lib/cloud-options-provider.ts
@@ -8,4 +8,4 @@ export class CloudOptionsProvider implements ICloudOptionsProvider {
 		};
 	}
 }
-$injector.register("cloudOptionsProvider", CloudOptionsProvider);
+$injector.register("nsCloudOptionsProvider", CloudOptionsProvider);

--- a/lib/commands/build-command-helper.ts
+++ b/lib/commands/build-command-helper.ts
@@ -6,7 +6,7 @@ export class BuildCommandHelper implements IBuildCommandHelper {
 		return this.$injector.resolve<ILocalBuildService>("localBuildService");
 	}
 
-	constructor(private $cloudBuildService: ICloudBuildService,
+	constructor(private $nsCloudBuildService: ICloudBuildService,
 		private $errors: IErrors,
 		private $logger: ILogger,
 		private $prompter: IPrompter,
@@ -87,7 +87,7 @@ export class BuildCommandHelper implements IBuildCommandHelper {
 		} else {
 			const buildData = this.getCloudBuildData(platform);
 			buildData.buildConfiguration = CLOUD_BUILD_CONFIGURATIONS.RELEASE;
-			packagePath = (await this.$cloudBuildService.build(buildData.projectSettings,
+			packagePath = (await this.$nsCloudBuildService.build(buildData.projectSettings,
 				buildData.platform, buildData.buildConfiguration,
 				buildData.androidBuildData,
 				buildData.iOSBuildData)).qrData.originalUrl;
@@ -97,4 +97,4 @@ export class BuildCommandHelper implements IBuildCommandHelper {
 	}
 }
 
-$injector.register("buildCommandHelper", BuildCommandHelper);
+$injector.register("nsCloudBuildCommandHelper", BuildCommandHelper);

--- a/lib/commands/cloud-build.ts
+++ b/lib/commands/cloud-build.ts
@@ -2,15 +2,15 @@ export class CloudBuild implements ICommand {
 	public allowedParameters: ICommandParameter[];
 
 	constructor(private $errors: IErrors,
-		private $buildCommandHelper: IBuildCommandHelper,
+		private $nsCloudBuildCommandHelper: IBuildCommandHelper,
 		private $projectData: IProjectData,
-		private $cloudBuildService: ICloudBuildService) {
+		private $nsCloudBuildService: ICloudBuildService) {
 		this.$projectData.initializeProjectData();
 	}
 
 	public async execute(args: string[]): Promise<void> {
-		const buildData = this.$buildCommandHelper.getCloudBuildData(args[0]);
-		await this.$cloudBuildService.build(buildData.projectSettings,
+		const buildData = this.$nsCloudBuildCommandHelper.getCloudBuildData(args[0]);
+		await this.$nsCloudBuildService.build(buildData.projectSettings,
 			buildData.platform, buildData.buildConfiguration,
 			buildData.androidBuildData,
 			buildData.iOSBuildData);

--- a/lib/commands/cloud-codesign.ts
+++ b/lib/commands/cloud-codesign.ts
@@ -13,7 +13,7 @@ export class CloudCodesignCommand implements ICommand {
 		private $errors: IErrors,
 		private $projectData: IProjectData,
 		private $prompter: IPrompter,
-		private $cloudCodesignService: ICloudCodesignService) {
+		private $nsCloudCodesignService: ICloudCodesignService) {
 		this.$projectData.initializeProjectData();
 	}
 
@@ -38,7 +38,7 @@ export class CloudCodesignCommand implements ICommand {
 			attachedDevices: this.devices
 		};
 
-		await this.$cloudCodesignService.generateCodesignFiles(codesignData, this.$projectData.projectDir);
+		await this.$nsCloudCodesignService.generateCodesignFiles(codesignData, this.$projectData.projectDir);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/commands/cloud-lib-version.ts
+++ b/lib/commands/cloud-lib-version.ts
@@ -1,12 +1,12 @@
 export class CloudLibVersion implements ICommand {
-	constructor(private $packageInfoService: IPackageInfoService,
+	constructor(private $nsCloudPackageInfoService: IPackageInfoService,
 		private $logger: ILogger) {
 	}
 
 	public allowedParameters: ICommandParameter[] = [];
 
 	public async execute(args: string[]): Promise<void> {
-		this.$logger.info(this.$packageInfoService.getVersion());
+		this.$logger.info(this.$nsCloudPackageInfoService.getVersion());
 	}
 }
 

--- a/lib/commands/cloud-publish.ts
+++ b/lib/commands/cloud-publish.ts
@@ -4,10 +4,10 @@ import { isInteractive } from "../helpers";
 abstract class CloudPublish implements ICommand {
 	public allowedParameters: ICommandParameter[];
 	public get dashedOptions() {
-		return this.$cloudOptionsProvider.dashedOptions;
+		return this.$nsCloudOptionsProvider.dashedOptions;
 	}
 
-	constructor(private $cloudOptionsProvider: ICloudOptionsProvider,
+	constructor(private $nsCloudOptionsProvider: ICloudOptionsProvider,
 		protected $prompter: IPrompter,
 		protected $projectData: IProjectData,
 		protected $options: ICloudOptions,
@@ -20,15 +20,15 @@ abstract class CloudPublish implements ICommand {
 }
 
 export class CloudPublishAndroid extends CloudPublish implements ICommand {
-	constructor($cloudOptionsProvider: ICloudOptionsProvider,
-		private $buildCommandHelper: IBuildCommandHelper,
-		private $cloudPublishService: ICloudPublishService,
+	constructor($nsCloudOptionsProvider: ICloudOptionsProvider,
+		private $nsCloudBuildCommandHelper: IBuildCommandHelper,
+		private $nsCloudPublishService: ICloudPublishService,
 		private $errors: IErrors,
 		protected $prompter: IPrompter,
 		protected $projectData: IProjectData,
 		protected $options: ICloudOptions,
 		protected $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) {
-		super($cloudOptionsProvider, $prompter, $projectData, $options, $devicePlatformsConstants);
+		super($nsCloudOptionsProvider, $prompter, $projectData, $options, $devicePlatformsConstants);
 	}
 
 	public async execute(args: string[]): Promise<void> {
@@ -43,8 +43,8 @@ export class CloudPublishAndroid extends CloudPublish implements ICommand {
 			track = await this.$prompter.getString("Track", { defaultAction: () => DEFAULT_ANDROID_PUBLISH_TRACK });
 		}
 
-		const packagePath = await this.$buildCommandHelper.buildForPublishingPlatform(this.$devicePlatformsConstants.Android);
-		return this.$cloudPublishService.publishToGooglePlay({
+		const packagePath = await this.$nsCloudBuildCommandHelper.buildForPublishingPlatform(this.$devicePlatformsConstants.Android);
+		return this.$nsCloudPublishService.publishToGooglePlay({
 			track,
 			pathToAuthJson,
 			packagePaths: [packagePath],
@@ -64,27 +64,27 @@ export class CloudPublishAndroid extends CloudPublish implements ICommand {
 $injector.registerCommand("cloud|publish|android", CloudPublishAndroid);
 
 export class CloudPublishIos extends CloudPublish implements ICommand {
-	constructor($cloudOptionsProvider: ICloudOptionsProvider,
-		private $buildCommandHelper: IBuildCommandHelper,
-		private $cloudPublishService: ICloudPublishService,
+	constructor($nsCloudOptionsProvider: ICloudOptionsProvider,
+		private $nsCloudBuildCommandHelper: IBuildCommandHelper,
+		private $nsCloudPublishService: ICloudPublishService,
 		private $errors: IErrors,
 		protected $prompter: IPrompter,
 		protected $projectData: IProjectData,
 		protected $options: ICloudOptions,
 		protected $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) {
-		super($cloudOptionsProvider, $prompter, $projectData, $options, $devicePlatformsConstants);
+		super($nsCloudOptionsProvider, $prompter, $projectData, $options, $devicePlatformsConstants);
 	}
 
 	public async execute(args: string[]): Promise<void> {
-		const credentials = await this.$buildCommandHelper.getAppleCredentials(args);
-		const packagePath = await this.$buildCommandHelper.buildForPublishingPlatform(this.$devicePlatformsConstants.iOS);
+		const credentials = await this.$nsCloudBuildCommandHelper.getAppleCredentials(args);
+		const packagePath = await this.$nsCloudBuildCommandHelper.buildForPublishingPlatform(this.$devicePlatformsConstants.iOS);
 		const itunesPublishdata: IItunesConnectPublishData = {
 			credentials,
 			packagePaths: [packagePath],
 			projectDir: this.$projectData.projectDir
 		};
 
-		await this.$cloudPublishService.publishToItunesConnect(itunesPublishdata);
+		await this.$nsCloudPublishService.publishToItunesConnect(itunesPublishdata);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/commands/config/config-apply.ts
+++ b/lib/commands/config/config-apply.ts
@@ -1,13 +1,13 @@
 export class ConfigApplyCommand implements ICommand {
-	constructor(private $serverConfigManager: IServerConfigManager,
+	constructor(private $nsCloudServerConfigManager: IServerConfigManager,
 		private $stringParameterBuilder: IStringParameterBuilder) { }
 
 	public allowedParameters: ICommandParameter[] = [this.$stringParameterBuilder.createMandatoryParameter("Configuration name cannot be empty.")];
 
 	public async execute(args: string[]): Promise<void> {
 		const configurationName = args[0];
-		this.$serverConfigManager.applyConfig(configurationName);
-		this.$serverConfigManager.printConfigData();
+		this.$nsCloudServerConfigManager.applyConfig(configurationName);
+		this.$nsCloudServerConfigManager.printConfigData();
 	}
 }
 

--- a/lib/commands/config/config-get.ts
+++ b/lib/commands/config/config-get.ts
@@ -1,10 +1,10 @@
 export class ConfigGetCommand implements ICommand {
-	constructor(private $serverConfigManager: IServerConfigManager) { }
+	constructor(private $nsCloudServerConfigManager: IServerConfigManager) { }
 
 	public allowedParameters: ICommandParameter[] = [];
 
 	public async execute(args: string[]): Promise<void> {
-		this.$serverConfigManager.printConfigData();
+		this.$nsCloudServerConfigManager.printConfigData();
 	}
 }
 

--- a/lib/commands/config/config-reset.ts
+++ b/lib/commands/config/config-reset.ts
@@ -1,11 +1,11 @@
 export class ConfigResetCommand implements ICommand {
-	constructor(private $serverConfigManager: IServerConfigManager,
+	constructor(private $nsCloudServerConfigManager: IServerConfigManager,
 		private $logger: ILogger) { }
 
 	public allowedParameters: ICommandParameter[] = [];
 
 	public async execute(args: string[]): Promise<void> {
-		this.$serverConfigManager.reset();
+		this.$nsCloudServerConfigManager.reset();
 		this.$logger.info("Server configuration successfully reset.");
 	}
 }

--- a/lib/commands/config/config-set.ts
+++ b/lib/commands/config/config-set.ts
@@ -1,13 +1,13 @@
 export class ConfigApplyCommand implements ICommand {
-	constructor(private $serverConfigManager: IServerConfigManager,
+	constructor(private $nsCloudServerConfigManager: IServerConfigManager,
 		private $stringParameterBuilder: IStringParameterBuilder) { }
 
 	public allowedParameters: ICommandParameter[] = [this.$stringParameterBuilder.createMandatoryParameter("You must specify path to configuration file.")];
 
 	public async execute(args: string[]): Promise<void> {
 		const configurationFile = args[0];
-		this.$serverConfigManager.applyConfig(null, { configurationFile: configurationFile });
-		this.$serverConfigManager.printConfigData();
+		this.$nsCloudServerConfigManager.applyConfig(null, { configurationFile: configurationFile });
+		this.$nsCloudServerConfigManager.printConfigData();
 	}
 }
 

--- a/lib/commands/dev-login.ts
+++ b/lib/commands/dev-login.ts
@@ -4,14 +4,14 @@ export class DevLoginCommand implements ICommand {
 		this.$stringParameterBuilder.createMandatoryParameter("Missing user name or password.")
 	];
 
-	constructor(private $authenticationService: IAuthenticationService,
+	constructor(private $nsCloudAuthenticationService: IAuthenticationService,
 		private $errors: IErrors,
 		private $logger: ILogger,
 		private $stringParameterBuilder: IStringParameterBuilder) { }
 
 	public async execute(args: string[]): Promise<void> {
 		try {
-			await this.$authenticationService.devLogin(args[0], args[1]);
+			await this.$nsCloudAuthenticationService.devLogin(args[0], args[1]);
 		} catch (err) {
 			this.$errors.failWithoutHelp(err.message);
 		}

--- a/lib/commands/kill-server.ts
+++ b/lib/commands/kill-server.ts
@@ -1,12 +1,12 @@
 export class KillServer implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
 
-	constructor(private $cloudDeviceEmulator: ICloudDeviceEmulator,
+	constructor(private $nsCloudDeviceEmulator: ICloudDeviceEmulator,
 		private $logger: ILogger) { }
 
 	public async execute(args: string[]): Promise<void> {
 		this.$logger.info("Killing server");
-		await this.$cloudDeviceEmulator.killServer();
+		await this.$nsCloudDeviceEmulator.killServer();
 	}
 }
 

--- a/lib/commands/login.ts
+++ b/lib/commands/login.ts
@@ -1,13 +1,13 @@
 export class LoginCommand implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
 
-	constructor(private $authenticationService: IAuthenticationService,
+	constructor(private $nsCloudAuthenticationService: IAuthenticationService,
 		private $commandsService: ICommandsService,
 		private $logger: ILogger,
 		private $options: IOptions) { }
 
 	public async execute(args: string[]): Promise<void> {
-		await this.$authenticationService.login({ timeout: this.$options.timeout });
+		await this.$nsCloudAuthenticationService.login({ timeout: this.$options.timeout });
 		this.$logger.info("Successfully logged in.");
 		await this.$commandsService.tryExecuteCommand("user", []);
 	}

--- a/lib/commands/logout.ts
+++ b/lib/commands/logout.ts
@@ -1,11 +1,11 @@
 export class LogoutCommand implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
 
-	constructor(private $authenticationService: IAuthenticationService,
+	constructor(private $nsCloudAuthenticationService: IAuthenticationService,
 		private $logger: ILogger) { }
 
 	public async execute(args: string[]): Promise<void> {
-		this.$authenticationService.logout();
+		this.$nsCloudAuthenticationService.logout();
 		this.$logger.info("Successfully logged out.");
 	}
 }

--- a/lib/commands/user.ts
+++ b/lib/commands/user.ts
@@ -3,11 +3,11 @@ import { EOL } from "os";
 export class UserCommand implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
 
-	constructor(private $userService: IUserService,
+	constructor(private $nsCloudUserService: IUserService,
 		private $logger: ILogger) { }
 
 	public async execute(args: string[]): Promise<void> {
-		const user = this.$userService.getUser();
+		const user = this.$nsCloudUserService.getUser();
 		let message: string;
 
 		if (!user) {

--- a/lib/http-server.ts
+++ b/lib/http-server.ts
@@ -66,4 +66,4 @@ export class HttpServer implements IHttpServer {
 	}
 }
 
-$injector.register("httpServer", HttpServer);
+$injector.register("nsCloudHttpServer", HttpServer);

--- a/lib/itms-services-plist-helper.ts
+++ b/lib/itms-services-plist-helper.ts
@@ -34,4 +34,4 @@ export class ItmsServicesPlistHelper implements IItmsServicesPlistHelper { // Us
 	}
 }
 
-$injector.register("itmsServicesPlistHelper", ItmsServicesPlistHelper);
+$injector.register("nsCloudItmsServicesPlistHelper", ItmsServicesPlistHelper);

--- a/lib/mobile/device/cloud-emulator-application-manager.ts
+++ b/lib/mobile/device/cloud-emulator-application-manager.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from "events";
 export class CloudEmulatorApplicationManager extends EventEmitter implements Mobile.IDeviceApplicationManager {
 
 	constructor(private basicInfo: ICloudEmulatorDeviceBasicInfo,
-		private $cloudEmulatorService: ICloudEmulatorService) {
+		private $nsCloudEmulatorService: ICloudEmulatorService) {
 		super();
 	}
 
@@ -12,8 +12,8 @@ export class CloudEmulatorApplicationManager extends EventEmitter implements Mob
 	}
 
 	public async installApplication(packageFilePath: string): Promise<void> {
-		await this.$cloudEmulatorService.deployApp(packageFilePath, this.basicInfo.os);
-		return this.$cloudEmulatorService.refereshEmulator(this.basicInfo.identifier);
+		await this.$nsCloudEmulatorService.deployApp(packageFilePath, this.basicInfo.os);
+		return this.$nsCloudEmulatorService.refereshEmulator(this.basicInfo.identifier);
 	}
 
 	public async isApplicationInstalled(appIdentifier: string): Promise<boolean> {

--- a/lib/mobile/mobile-core/cloud-emulator-device-discovery.ts
+++ b/lib/mobile/mobile-core/cloud-emulator-device-discovery.ts
@@ -6,7 +6,7 @@ export class CloudEmulatorDeviceDiscovery extends EventEmitter implements Mobile
 	private devices: IDictionary<Mobile.IDevice> = {};
 	private _hasStartedLookingForDevices = false;
 
-	constructor(private $cloudDeviceEmulator: ICloudDeviceEmulator,
+	constructor(private $nsCloudDeviceEmulator: ICloudDeviceEmulator,
 		private $injector: IInjector) {
 		super();
 	}
@@ -29,15 +29,15 @@ export class CloudEmulatorDeviceDiscovery extends EventEmitter implements Mobile
 	public async startLookingForDevices(): Promise<void> {
 		if (!this._hasStartedLookingForDevices) {
 			this._hasStartedLookingForDevices = true;
-			_.values(this.$cloudDeviceEmulator.deviceEmitter.getCurrentlyAttachedDevices()).forEach(basicInfo => {
+			_.values(this.$nsCloudDeviceEmulator.deviceEmitter.getCurrentlyAttachedDevices()).forEach(basicInfo => {
 				this.addCloudDevice(basicInfo);
 			});
 
-			this.$cloudDeviceEmulator.deviceEmitter.on(DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND, (basicInfo: ICloudEmulatorDeviceBasicInfo) => {
+			this.$nsCloudDeviceEmulator.deviceEmitter.on(DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND, (basicInfo: ICloudEmulatorDeviceBasicInfo) => {
 				this.addCloudDevice(basicInfo);
 			});
 
-			this.$cloudDeviceEmulator.deviceEmitter.on(DEVICE_DISCOVERY_EVENTS.DEVICE_LOST, (basicInfo: ICloudEmulatorDeviceBasicInfo) => {
+			this.$nsCloudDeviceEmulator.deviceEmitter.on(DEVICE_DISCOVERY_EVENTS.DEVICE_LOST, (basicInfo: ICloudEmulatorDeviceBasicInfo) => {
 				this.removeDevice(basicInfo.identifier);
 			});
 		}
@@ -59,4 +59,4 @@ export class CloudEmulatorDeviceDiscovery extends EventEmitter implements Mobile
 	}
 }
 
-$injector.register("cloudEmulatorDeviceDiscovery", CloudEmulatorDeviceDiscovery);
+$injector.register("nsCloudEmulatorDeviceDiscovery", CloudEmulatorDeviceDiscovery);

--- a/lib/server-config-manager.ts
+++ b/lib/server-config-manager.ts
@@ -70,4 +70,4 @@ export class ServerConfigManager implements IServerConfigManager {
 	}
 }
 
-$injector.register("serverConfigManager", ServerConfigManager);
+$injector.register("nsCloudServerConfigManager", ServerConfigManager);

--- a/lib/services/application-service.ts
+++ b/lib/services/application-service.ts
@@ -20,4 +20,4 @@ export class ApplicationService implements IApplicationService {
 	}
 }
 
-$injector.register("applicationService", ApplicationService);
+$injector.register("nsCloudApplicationService", ApplicationService);

--- a/lib/services/authentication-service.ts
+++ b/lib/services/authentication-service.ts
@@ -8,12 +8,12 @@ export class AuthenticationService implements IAuthenticationService {
 	private localhostServer: Server;
 	private rejectLoginPromiseAction: (data: any) => void;
 
-	constructor(private $authCloudService: IAuthCloudService,
+	constructor(private $nsCloudAuthCloudService: IAuthCloudService,
 		private $fs: IFileSystem,
-		private $httpServer: IHttpServer,
+		private $nsCloudHttpServer: IHttpServer,
 		private $logger: ILogger,
 		private $opener: IOpener,
-		private $userService: IUserService) { }
+		private $nsCloudUserService: IUserService) { }
 
 	public async login(options?: ILoginOptions): Promise<IUser> {
 		options = options || {};
@@ -30,7 +30,7 @@ export class AuthenticationService implements IAuthenticationService {
 		this.$logger.info("Launching login page in browser.");
 
 		let loginUrl: string;
-		this.localhostServer = this.$httpServer.createServer({
+		this.localhostServer = this.$nsCloudHttpServer.createServer({
 			routes: {
 				"/": (request: ServerRequest, response: ServerResponse) => {
 					this.$logger.debug("Login complete: " + request.url);
@@ -48,7 +48,7 @@ export class AuthenticationService implements IAuthenticationService {
 						authCompleteResolveAction(decodedResponse);
 						response.end();
 					} else {
-						this.$httpServer.redirect(response, loginUrl);
+						this.$nsCloudHttpServer.redirect(response, loginUrl);
 					}
 				}
 			}
@@ -64,7 +64,7 @@ export class AuthenticationService implements IAuthenticationService {
 
 			const port = this.localhostServer.address().port;
 
-			loginUrl = this.$authCloudService.getLoginUrl(port);
+			loginUrl = this.$nsCloudAuthCloudService.getLoginUrl(port);
 
 			this.$logger.debug("Login URL is '%s'", loginUrl);
 
@@ -97,7 +97,7 @@ export class AuthenticationService implements IAuthenticationService {
 		}
 
 		const userData: IUserData = JSON.parse(loginResponse);
-		this.$userService.setUserData(userData);
+		this.$nsCloudUserService.setUserData(userData);
 
 		const userInfo = userData.userInfo;
 
@@ -105,8 +105,8 @@ export class AuthenticationService implements IAuthenticationService {
 	}
 
 	public async devLogin(username: string, password: string): Promise<IUser> {
-		const userData = await this.$authCloudService.devLogin(username, password);
-		this.$userService.setUserData(userData);
+		const userData = await this.$nsCloudAuthCloudService.devLogin(username, password);
+		this.$nsCloudUserService.setUserData(userData);
 
 		return userData.userInfo;
 	}
@@ -128,7 +128,7 @@ export class AuthenticationService implements IAuthenticationService {
 	public logout(options?: IOpenActionOptions): void {
 		options = options || {};
 
-		const logoutUrl = this.$authCloudService.getLogoutUrl();
+		const logoutUrl = this.$nsCloudAuthCloudService.getLogoutUrl();
 		this.$logger.trace(`Logging out. Logout url is: ${logoutUrl}`);
 
 		if (options.openAction) {
@@ -137,17 +137,17 @@ export class AuthenticationService implements IAuthenticationService {
 			this.$opener.open(logoutUrl);
 		}
 
-		this.$userService.clearUserData();
+		this.$nsCloudUserService.clearUserData();
 	}
 
 	public async refreshCurrentUserToken(): Promise<void> {
-		const userData = this.$userService.getUserData();
-		const token = await this.$authCloudService.refreshToken(userData.refreshToken);
-		this.$userService.setToken(token);
+		const userData = this.$nsCloudUserService.getUserData();
+		const token = await this.$nsCloudAuthCloudService.refreshToken(userData.refreshToken);
+		this.$nsCloudUserService.setToken(token);
 	}
 
 	public async isUserLoggedIn(): Promise<boolean> {
-		if (this.$userService.hasUser()) {
+		if (this.$nsCloudUserService.hasUser()) {
 			const tokenState = await this.getCurrentUserTokenState();
 			if (tokenState.isTokenValid) {
 				return true;
@@ -169,8 +169,8 @@ export class AuthenticationService implements IAuthenticationService {
 	}
 
 	private async getCurrentUserTokenState(): Promise<ITokenState> {
-		const userData = this.$userService.getUserData();
-		const tokenState = await this.$authCloudService.getTokenState(userData.accessToken);
+		const userData = this.$nsCloudUserService.getUserData();
+		const tokenState = await this.$nsCloudAuthCloudService.getTokenState(userData.accessToken);
 		return tokenState;
 	}
 
@@ -180,4 +180,4 @@ export class AuthenticationService implements IAuthenticationService {
 	}
 }
 
-$injector.register("authenticationService", AuthenticationService);
+$injector.register("nsCloudAuthenticationService", AuthenticationService);

--- a/lib/services/cloud-codesign-service.ts
+++ b/lib/services/cloud-codesign-service.ts
@@ -16,7 +16,7 @@ export class CloudCodesignService extends CloudService implements ICloudCodesign
 	constructor($fs: IFileSystem,
 		$httpClient: Server.IHttpClient,
 		$logger: ILogger,
-		private $buildCloudService: IBuildCloudService,
+		private $nsCloudBuildCloudService: IBuildCloudService,
 		private $errors: IErrors,
 		private $projectHelper: IProjectHelper,
 		private $projectDataService: IProjectDataService,
@@ -74,7 +74,7 @@ export class CloudCodesignService extends CloudService implements ICloudCodesign
 
 		const projectData = this.$projectDataService.getProjectData(projectDir);
 		const codesignRequest = await this.prepareCodesignRequest(buildId, codesignData, projectData);
-		const codesignResponse: IServerResponse = await this.$buildCloudService.generateCodesignFiles(codesignRequest);
+		const codesignResponse: IServerResponse = await this.$nsCloudBuildCloudService.generateCodesignFiles(codesignRequest);
 		this.$logger.trace(`Codesign response: ${JSON.stringify(codesignResponse)}`);
 
 		try {
@@ -138,4 +138,4 @@ export class CloudCodesignService extends CloudService implements ICloudCodesign
 	}
 }
 
-$injector.register("cloudCodesignService", CloudCodesignService);
+$injector.register("nsCloudCodesignService", CloudCodesignService);

--- a/lib/services/cloud-emulator-launcher.ts
+++ b/lib/services/cloud-emulator-launcher.ts
@@ -1,11 +1,11 @@
 export class CloudEmulatorLauncher implements ICloudEmulatorLauncher {
 
-	constructor(private $cloudEmulatorService: ICloudEmulatorService) { }
+	constructor(private $nsCloudEmulatorService: ICloudEmulatorService) { }
 
 	public async startEmulator(data: ICloudEmulatorStartData): Promise<string> {
-		const response: ICloudEmulatorResponse = await this.$cloudEmulatorService.deployApp(data.packageFile, data.platform);
-		return this.$cloudEmulatorService.startEmulator(response.publicKey, data.platform, data.model);
+		const response: ICloudEmulatorResponse = await this.$nsCloudEmulatorService.deployApp(data.packageFile, data.platform);
+		return this.$nsCloudEmulatorService.startEmulator(response.publicKey, data.platform, data.model);
 	}
 }
 
-$injector.register("cloudEmulatorLauncher", CloudEmulatorLauncher);
+$injector.register("nsCloudEmulatorLauncher", CloudEmulatorLauncher);

--- a/lib/services/cloud-publish-service.ts
+++ b/lib/services/cloud-publish-service.ts
@@ -21,9 +21,9 @@ export class CloudPublishService extends CloudService implements ICloudPublishSe
 		$httpClient: Server.IHttpClient,
 		$logger: ILogger,
 		private $errors: IErrors,
-		private $buildCloudService: IBuildCloudService,
+		private $nsCloudBuildCloudService: IBuildCloudService,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
-		private $uploadService: IUploadService,
+		private $nsCloudUploadService: IUploadService,
 		private $projectDataService: IProjectDataService) {
 		super($fs, $httpClient, $logger);
 	}
@@ -93,7 +93,7 @@ export class CloudPublishService extends CloudService implements ICloudPublishSe
 		publishRequestData.packagePaths = await this.getPreparePackagePaths(publishDataCore);
 
 		this.$logger.info("Starting publishing.");
-		const response = await this.$buildCloudService.publish(publishRequestData);
+		const response = await this.$nsCloudBuildCloudService.publish(publishRequestData);
 
 		this.$logger.trace("Publish response", response);
 		const buildId = uuid.v4();
@@ -127,7 +127,7 @@ export class CloudPublishService extends CloudService implements ICloudPublishSe
 	private async getPreparePackagePaths(publishData: IPackagePaths): Promise<string[]> {
 		const preparedPackagePaths: string[] = [];
 		for (const packagePath of publishData.packagePaths) {
-			preparedPackagePaths.push(this.$fs.exists(packagePath) ? await this.$uploadService.uploadToS3(packagePath, basename(packagePath)) : packagePath);
+			preparedPackagePaths.push(this.$fs.exists(packagePath) ? await this.$nsCloudUploadService.uploadToS3(packagePath, basename(packagePath)) : packagePath);
 		}
 
 		return preparedPackagePaths;
@@ -148,4 +148,4 @@ export class CloudPublishService extends CloudService implements ICloudPublishSe
 	}
 }
 
-$injector.register("cloudPublishService", CloudPublishService);
+$injector.register("nsCloudPublishService", CloudPublishService);

--- a/lib/services/cloud-services/auth-cloud-service.ts
+++ b/lib/services/cloud-services/auth-cloud-service.ts
@@ -4,8 +4,8 @@ import { CloudServiceBase } from "./cloud-service-base";
 export class AuthCloudService extends CloudServiceBase implements IAuthCloudService {
 	protected serviceName: string = AUTH_SERVICE_NAME;
 
-	constructor(protected $cloudServicesProxy: ICloudServicesProxy) {
-		super($cloudServicesProxy);
+	constructor(protected $nsCloudServicesProxy: ICloudServicesProxy) {
+		super($nsCloudServicesProxy);
 	}
 
 	public getLoginUrl(port: number): string {
@@ -34,11 +34,11 @@ export class AuthCloudService extends CloudServiceBase implements IAuthCloudServ
 	}
 
 	private getAuthUrl(urlPath: string): string {
-		const proto = this.$cloudServicesProxy.getServiceProto(AUTH_SERVICE_NAME);
-		const host = this.$cloudServicesProxy.getServiceAddress(AUTH_SERVICE_NAME);
-		const url = this.$cloudServicesProxy.getUrlPath(AUTH_SERVICE_NAME, urlPath);
+		const proto = this.$nsCloudServicesProxy.getServiceProto(AUTH_SERVICE_NAME);
+		const host = this.$nsCloudServicesProxy.getServiceAddress(AUTH_SERVICE_NAME);
+		const url = this.$nsCloudServicesProxy.getUrlPath(AUTH_SERVICE_NAME, urlPath);
 		return `${proto}://${host}${url}`;
 	}
 }
 
-$injector.register("authCloudService", AuthCloudService);
+$injector.register("nsCloudAuthCloudService", AuthCloudService);

--- a/lib/services/cloud-services/build-cloud-service.ts
+++ b/lib/services/cloud-services/build-cloud-service.ts
@@ -5,8 +5,8 @@ import { CloudServiceBase } from "./cloud-service-base";
 export class BuildCloudService extends CloudServiceBase implements IBuildCloudService {
 	protected serviceName: string = BUILD_SERVICE_NAME;
 
-	constructor(protected $cloudRequestService: ICloudRequestService) {
-		super($cloudRequestService);
+	constructor(protected $nsCloudRequestService: ICloudRequestService) {
+		super($nsCloudRequestService);
 	}
 
 	public startBuild(buildRequest: IBuildRequestData): Promise<IServerResponse> {
@@ -30,4 +30,4 @@ export class BuildCloudService extends CloudServiceBase implements IBuildCloudSe
 	}
 }
 
-$injector.register("buildCloudService", BuildCloudService);
+$injector.register("nsCloudBuildCloudService", BuildCloudService);

--- a/lib/services/cloud-services/cloud-emulator-service.ts
+++ b/lib/services/cloud-services/cloud-emulator-service.ts
@@ -7,23 +7,23 @@ export class CloudEmulatorService extends CloudServiceBase implements ICloudEmul
 
 	protected serviceName = EMULATORS_SERVICE_NAME;
 
-	constructor(private $cloudDeviceEmulator: ICloudDeviceEmulator,
-		protected $cloudRequestService: ICloudRequestService,
-		private $uploadService: IUploadService,
+	constructor(private $nsCloudDeviceEmulator: ICloudDeviceEmulator,
+		protected $nsCloudRequestService: ICloudRequestService,
+		private $nsCloudUploadService: IUploadService,
 		private $fs: IFileSystem,
 		protected $options: IProfileDir) {
 
-		super($cloudRequestService);
+		super($nsCloudRequestService);
 	}
 
 	public async startEmulator(publicKey: string, platform: string, deviceType: string): Promise<string> {
-		const serverInfo = await this.$cloudDeviceEmulator.getSeverAddress();
+		const serverInfo = await this.$nsCloudDeviceEmulator.getSeverAddress();
 		return `http://${serverInfo.host}:${serverInfo.port}?publicKey=${publicKey}&device=${deviceType}`;
 	}
 
 	public async deployApp(fileLocation: string, platform: string): Promise<ICloudEmulatorResponse> {
 		if (this.$fs.exists(path.resolve(fileLocation))) {
-			fileLocation = await this.$uploadService.uploadToS3(fileLocation);
+			fileLocation = await this.$nsCloudUploadService.uploadToS3(fileLocation);
 		}
 
 		const cloudEmulatorKeys = this.getEmulatorCredentials(platform);
@@ -35,7 +35,7 @@ export class CloudEmulatorService extends CloudServiceBase implements ICloudEmul
 	}
 
 	public refereshEmulator(deviceIdentifier: string): Promise<void> {
-		return this.$cloudDeviceEmulator.refresh(deviceIdentifier);
+		return this.$nsCloudDeviceEmulator.refresh(deviceIdentifier);
 	}
 
 	private async createApp(url: string, platform: string): Promise<ICloudEmulatorResponse> {
@@ -69,4 +69,4 @@ export class CloudEmulatorService extends CloudServiceBase implements ICloudEmul
 	}
 }
 
-$injector.register("cloudEmulatorService", CloudEmulatorService);
+$injector.register("nsCloudEmulatorService", CloudEmulatorService);

--- a/lib/services/cloud-services/cloud-request-service.ts
+++ b/lib/services/cloud-services/cloud-request-service.ts
@@ -1,21 +1,21 @@
 import { HTTP_STATUS_CODES } from "../../constants";
 
 export class CloudRequestService implements ICloudRequestService {
-	constructor(private $authenticationService: IAuthenticationService,
-		private $cloudServicesProxy: ICloudServicesProxy,
+	constructor(private $nsCloudAuthenticationService: IAuthenticationService,
+		private $nsCloudServicesProxy: ICloudServicesProxy,
 		private $logger: ILogger) { }
 
 	public async call<T>(options: ICloudRequestOptions): Promise<T> {
 		try {
 			// Try to send the request.
-			return await this.$cloudServicesProxy.call<T>(options);
+			return await this.$nsCloudServicesProxy.call<T>(options);
 		} catch (requestError) {
 			// If the server returns 401 we must try to get new access token using the refresh token and retry the request.
 			if (requestError.response.statusCode === HTTP_STATUS_CODES.UNAUTHORIZED) {
 				this.$logger.trace("Access token expired. Trying to issue a new one.");
 				try {
-					await this.$authenticationService.refreshCurrentUserToken();
-					return this.$cloudServicesProxy.call<T>(options);
+					await this.$nsCloudAuthenticationService.refreshCurrentUserToken();
+					return this.$nsCloudServicesProxy.call<T>(options);
 				} catch (refreshTokenError) {
 					this.$logger.trace("Cannot issue new access token. Reason is:");
 					this.$logger.trace(refreshTokenError);
@@ -30,4 +30,4 @@ export class CloudRequestService implements ICloudRequestService {
 	}
 }
 
-$injector.register("cloudRequestService", CloudRequestService);
+$injector.register("nsCloudRequestService", CloudRequestService);

--- a/lib/services/cloud-services/cloud-services-proxy.ts
+++ b/lib/services/cloud-services/cloud-services-proxy.ts
@@ -6,9 +6,9 @@ export class CloudServicesProxy implements ICloudServicesProxy {
 	constructor(private $errors: IErrors,
 		private $httpClient: Server.IHttpClient,
 		private $logger: ILogger,
-		private $serverConfigManager: IServerConfigManager,
-		private $userService: IUserService) {
-		this.serverConfig = this.$serverConfigManager.getCurrentConfigData();
+		private $nsCloudServerConfigManager: IServerConfigManager,
+		private $nsCloudUserService: IUserService) {
+		this.serverConfig = this.$nsCloudServerConfigManager.getCurrentConfigData();
 	}
 
 	public async call<T>(options: ICloudRequestOptions): Promise<T> {
@@ -17,8 +17,8 @@ export class CloudServicesProxy implements ICloudServicesProxy {
 
 		const headers = options.headers || Object.create(null);
 
-		if (!_.has(headers, HTTP_HEADERS.AUTHORIZATION) && this.$userService.hasUser()) {
-			headers[HTTP_HEADERS.AUTHORIZATION] = `Bearer ${this.$userService.getUserData().accessToken}`;
+		if (!_.has(headers, HTTP_HEADERS.AUTHORIZATION) && this.$nsCloudUserService.hasUser()) {
+			headers[HTTP_HEADERS.AUTHORIZATION] = `Bearer ${this.$nsCloudUserService.getUserData().accessToken}`;
 		}
 
 		if (options.accept) {
@@ -102,4 +102,4 @@ export class CloudServicesProxy implements ICloudServicesProxy {
 	}
 }
 
-$injector.register("cloudServicesProxy", CloudServicesProxy);
+$injector.register("nsCloudServicesProxy", CloudServicesProxy);

--- a/lib/services/cloud-services/code-commit-service.ts
+++ b/lib/services/cloud-services/code-commit-service.ts
@@ -5,8 +5,8 @@ import { CloudServiceBase } from "./cloud-service-base";
 export class CodeCommitService extends CloudServiceBase implements ICodeCommitService {
 	protected serviceName: string = CODE_COMMIT_SERVICE_NAME;
 
-	constructor(protected $cloudRequestService: ICloudRequestService) {
-		super($cloudRequestService);
+	constructor(protected $nsCloudRequestService: ICloudRequestService) {
+		super($nsCloudRequestService);
 	}
 
 	public getRepository(appId: string): Promise<IGetRepositoryResponse> {
@@ -18,4 +18,4 @@ export class CodeCommitService extends CloudServiceBase implements ICodeCommitSe
 	}
 }
 
-$injector.register("codeCommitService", CodeCommitService);
+$injector.register("nsCloudCodeCommitService", CodeCommitService);

--- a/lib/services/git-service.ts
+++ b/lib/services/git-service.ts
@@ -21,7 +21,7 @@ export class GitService implements IGitService {
 		private $hostInfo: IHostInfo,
 		private $logger: ILogger,
 		private $options: IProfileDir,
-		private $userService: IUserService) { }
+		private $nsCloudUserService: IUserService) { }
 
 	public async gitPushChanges(projectDir: string, remoteUrl: IRemoteUrl, codeCommitCredential: ICodeCommitCredentials, repositoryState?: IRepositoryState): Promise<void> {
 		this.cleanLocalRepositories();
@@ -159,7 +159,7 @@ export class GitService implements IGitService {
 
 	private getGitDirName(projectDir: string): string {
 		const shasumData = crypto.createHash("sha1");
-		shasumData.update(`${this.$userService.getUser().email}_${projectDir}`);
+		shasumData.update(`${this.$nsCloudUserService.getUser().email}_${projectDir}`);
 		const gitDirName = shasumData.digest("hex");
 
 		return gitDirName;
@@ -203,4 +203,4 @@ export class GitService implements IGitService {
 	}
 }
 
-$injector.register("gitService", GitService);
+$injector.register("nsCloudGitService", GitService);

--- a/lib/services/package-info-service.ts
+++ b/lib/services/package-info-service.ts
@@ -14,4 +14,4 @@ export class PackageInfoService implements IPackageInfoService {
 	}
 }
 
-$injector.register("packageInfoService", PackageInfoService);
+$injector.register("nsCloudPackageInfoService", PackageInfoService);

--- a/lib/services/upload-service.ts
+++ b/lib/services/upload-service.ts
@@ -6,7 +6,7 @@ export class UploadService implements IUploadService {
 
 	protected serviceName = BUILD_SERVICE_NAME;
 
-	constructor(private $buildCloudService: IBuildCloudService,
+	constructor(private $nsCloudBuildCloudService: IBuildCloudService,
 		private $httpClient: Server.IHttpClient,
 		private $errors: IErrors,
 		private $fs: IFileSystem) {
@@ -16,7 +16,7 @@ export class UploadService implements IUploadService {
 		fileNameInS3 = fileNameInS3 || uuid.v4();
 		let preSignedUrlData: IAmazonStorageEntry;
 		if (!uploadPreSignedUrl) {
-			preSignedUrlData = await this.$buildCloudService.getPresignedUploadUrlObject(fileNameInS3);
+			preSignedUrlData = await this.$nsCloudBuildCloudService.getPresignedUploadUrlObject(fileNameInS3);
 			uploadPreSignedUrl = preSignedUrlData.uploadPreSignedUrl;
 		}
 
@@ -45,4 +45,4 @@ export class UploadService implements IUploadService {
 	}
 }
 
-$injector.register("uploadService", UploadService);
+$injector.register("nsCloudUploadService", UploadService);

--- a/lib/services/user-service.ts
+++ b/lib/services/user-service.ts
@@ -5,8 +5,8 @@ export class UserService implements IUserService {
 	private userData: IUserData;
 	private userInfoDirectory: string;
 
-	private get $authCloudService(): IAuthCloudService {
-		return this.$injector.resolve("authCloudService");
+	private get $nsCloudAuthCloudService(): IAuthCloudService {
+		return this.$injector.resolve("nsCloudAuthCloudService");
 	}
 
 	constructor(private $injector: IInjector,
@@ -78,7 +78,7 @@ export class UserService implements IUserService {
 			return null;
 		}
 
-		const userInfo = await this.$authCloudService.getUserInfo();
+		const userInfo = await this.$nsCloudAuthCloudService.getUserInfo();
 		return userInfo.externalAvatarUrl;
 	}
 
@@ -87,4 +87,4 @@ export class UserService implements IUserService {
 	}
 }
 
-$injector.register("userService", UserService);
+$injector.register("nsCloudUserService", UserService);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {

--- a/test/commands/cloud-build.ts
+++ b/test/commands/cloud-build.ts
@@ -19,7 +19,7 @@ describe("cloud lib version command", () => {
 			info: loggerInfo
 		});
 
-		testInjector.register("packageInfoService", PackageInfoService);
+		testInjector.register("nsCloudPackageInfoService", PackageInfoService);
 		testInjector.registerCommand("command", CloudLibVersion);
 
 		await testInjector.resolveCommand("command").execute([]);

--- a/test/mobile/mobile-core/cloud-emulator-device-discovery.ts
+++ b/test/mobile/mobile-core/cloud-emulator-device-discovery.ts
@@ -34,12 +34,12 @@ describe("cloud emulator device discovery", () => {
 			const customEventEmitter = new CustomDeviceEmitter(devices);
 			const testInjector = new Yok();
 			testInjector.register("injector", testInjector);
-			testInjector.register("cloudDeviceEmulator", {
+			testInjector.register("nsCloudDeviceEmulator", {
 				get deviceEmitter() {
 					return customEventEmitter;
 				}
 			});
-			testInjector.register("cloudEmulatorService", { /* empty */ });
+			testInjector.register("nsCloudEmulatorService", { /* empty */ });
 			testInjector.register("mobileHelper", {
 				normalizePlatformName: (platform: string) => platform.toLowerCase()
 			});
@@ -50,10 +50,10 @@ describe("cloud emulator device discovery", () => {
 		it(`should attach ${DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND}/${DEVICE_DISCOVERY_EVENTS.DEVICE_LOST}`, async () => {
 			const injector = createTestInjector();
 
-			const cloudEmulatorDeviceDiscovery: Mobile.IDeviceDiscovery = injector.resolve(CloudEmulatorDeviceDiscovery);
-			await cloudEmulatorDeviceDiscovery.startLookingForDevices();
+			const nsCloudEmulatorDeviceDiscovery: Mobile.IDeviceDiscovery = injector.resolve(CloudEmulatorDeviceDiscovery);
+			await nsCloudEmulatorDeviceDiscovery.startLookingForDevices();
 
-			const deviceEmitter = injector.resolve("cloudDeviceEmulator").deviceEmitter;
+			const deviceEmitter = injector.resolve("nsCloudDeviceEmulator").deviceEmitter;
 
 			assert.deepEqual(deviceEmitter.listenerCount(DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND), 1);
 			assert.deepEqual(deviceEmitter.listenerCount(DEVICE_DISCOVERY_EVENTS.DEVICE_LOST), 1);
@@ -62,11 +62,11 @@ describe("cloud emulator device discovery", () => {
 		it(`should not attach ${DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND}/${DEVICE_DISCOVERY_EVENTS.DEVICE_LOST} multiple times upon multiple calls`, async () => {
 			const injector = createTestInjector();
 
-			const cloudEmulatorDeviceDiscovery: Mobile.IDeviceDiscovery = injector.resolve(CloudEmulatorDeviceDiscovery);
-			await cloudEmulatorDeviceDiscovery.startLookingForDevices();
-			await cloudEmulatorDeviceDiscovery.startLookingForDevices();
+			const nsCloudEmulatorDeviceDiscovery: Mobile.IDeviceDiscovery = injector.resolve(CloudEmulatorDeviceDiscovery);
+			await nsCloudEmulatorDeviceDiscovery.startLookingForDevices();
+			await nsCloudEmulatorDeviceDiscovery.startLookingForDevices();
 
-			const deviceEmitter = injector.resolve("cloudDeviceEmulator").deviceEmitter;
+			const deviceEmitter = injector.resolve("nsCloudDeviceEmulator").deviceEmitter;
 
 			assert.deepEqual(deviceEmitter.listenerCount(DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND), 1);
 			assert.deepEqual(deviceEmitter.listenerCount(DEVICE_DISCOVERY_EVENTS.DEVICE_LOST), 1);
@@ -76,14 +76,14 @@ describe("cloud emulator device discovery", () => {
 			const injector = createTestInjector(initialDevices);
 			let hasDetectedDevice = false;
 
-			const cloudEmulatorDeviceDiscovery: Mobile.IDeviceDiscovery = injector.resolve(CloudEmulatorDeviceDiscovery);
-			cloudEmulatorDeviceDiscovery.on(DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND, (device: Mobile.IDevice) => {
+			const nsCloudEmulatorDeviceDiscovery: Mobile.IDeviceDiscovery = injector.resolve(CloudEmulatorDeviceDiscovery);
+			nsCloudEmulatorDeviceDiscovery.on(DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND, (device: Mobile.IDevice) => {
 				hasDetectedDevice = true;
 				assert.deepEqual(device.deviceInfo.identifier, customDevice.identifier);
 				assert.deepEqual(device.deviceInfo.model, customDevice.model);
 			});
 
-			await cloudEmulatorDeviceDiscovery.startLookingForDevices();
+			await nsCloudEmulatorDeviceDiscovery.startLookingForDevices();
 			assert.isTrue(hasDetectedDevice);
 		});
 
@@ -91,16 +91,16 @@ describe("cloud emulator device discovery", () => {
 			const injector = createTestInjector();
 			let hasDetectedDevice = false;
 
-			const deviceEmitter: EventEmitter = injector.resolve("cloudDeviceEmulator").deviceEmitter;
+			const deviceEmitter: EventEmitter = injector.resolve("nsCloudDeviceEmulator").deviceEmitter;
 
-			const cloudEmulatorDeviceDiscovery: Mobile.IDeviceDiscovery = injector.resolve(CloudEmulatorDeviceDiscovery);
-			cloudEmulatorDeviceDiscovery.on(DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND, (device: Mobile.IDevice) => {
+			const nsCloudEmulatorDeviceDiscovery: Mobile.IDeviceDiscovery = injector.resolve(CloudEmulatorDeviceDiscovery);
+			nsCloudEmulatorDeviceDiscovery.on(DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND, (device: Mobile.IDevice) => {
 				hasDetectedDevice = true;
 				assert.deepEqual(device.deviceInfo.identifier, customDevice.identifier);
 				assert.deepEqual(device.deviceInfo.model, customDevice.model);
 			});
 
-			await cloudEmulatorDeviceDiscovery.startLookingForDevices();
+			await nsCloudEmulatorDeviceDiscovery.startLookingForDevices();
 			deviceEmitter.emit(DEVICE_DISCOVERY_EVENTS.DEVICE_FOUND, customDevice);
 			assert.isTrue(hasDetectedDevice);
 		});
@@ -109,16 +109,16 @@ describe("cloud emulator device discovery", () => {
 			const injector = createTestInjector(initialDevices);
 			let hasLostDevice = false;
 
-			const deviceEmitter: EventEmitter = injector.resolve("cloudDeviceEmulator").deviceEmitter;
+			const deviceEmitter: EventEmitter = injector.resolve("nsCloudDeviceEmulator").deviceEmitter;
 
-			const cloudEmulatorDeviceDiscovery: Mobile.IDeviceDiscovery = injector.resolve(CloudEmulatorDeviceDiscovery);
-			cloudEmulatorDeviceDiscovery.on(DEVICE_DISCOVERY_EVENTS.DEVICE_LOST, (device: Mobile.IDevice) => {
+			const nsCloudEmulatorDeviceDiscovery: Mobile.IDeviceDiscovery = injector.resolve(CloudEmulatorDeviceDiscovery);
+			nsCloudEmulatorDeviceDiscovery.on(DEVICE_DISCOVERY_EVENTS.DEVICE_LOST, (device: Mobile.IDevice) => {
 				hasLostDevice = true;
 				assert.deepEqual(device.deviceInfo.identifier, customDevice.identifier);
 				assert.deepEqual(device.deviceInfo.model, customDevice.model);
 			});
 
-			await cloudEmulatorDeviceDiscovery.startLookingForDevices();
+			await nsCloudEmulatorDeviceDiscovery.startLookingForDevices();
 			deviceEmitter.emit(DEVICE_DISCOVERY_EVENTS.DEVICE_LOST, customDevice);
 
 			assert.isTrue(hasLostDevice);

--- a/test/services/cloud-emulator-service.ts
+++ b/test/services/cloud-emulator-service.ts
@@ -11,7 +11,7 @@ describe("cloud emulator service", () => {
 
 		function createTestInjector(): IInjector {
 			const testInjector = new Yok();
-			testInjector.register("cloudRequestService", {
+			testInjector.register("nsCloudRequestService", {
 				call: async () => emulatorCredentials
 			});
 			testInjector.register("fs", {
@@ -19,10 +19,10 @@ describe("cloud emulator service", () => {
 				readJson: () => ({}),
 				writeJson: () => { /* empty */ }
 			});
-			testInjector.register("uploadService", {
+			testInjector.register("nsCloudUploadService", {
 				uploadToS3: async (url: string) => url
 			});
-			testInjector.register("cloudDeviceEmulator", { /* empty */ });
+			testInjector.register("nsCloudDeviceEmulator", { /* empty */ });
 			testInjector.register("options", {
 				profileDir: "test"
 			});
@@ -33,14 +33,14 @@ describe("cloud emulator service", () => {
 		it("should upload to S3 in case a local file is passed", async () => {
 			const injector = createTestInjector();
 			let hasUploadedToS3 = false;
-			injector.resolve("uploadService").uploadToS3 = (url: string) => {
+			injector.resolve("nsCloudUploadService").uploadToS3 = (url: string) => {
 				if (url === filePath) {
 					hasUploadedToS3 = true;
 				}
 			};
 
-			const cloudEmulatorService: ICloudEmulatorService = injector.resolve(CloudEmulatorService);
-			await cloudEmulatorService.deployApp(filePath, platform);
+			const nsCloudEmulatorService: ICloudEmulatorService = injector.resolve(CloudEmulatorService);
+			await nsCloudEmulatorService.deployApp(filePath, platform);
 
 			assert.isTrue(hasUploadedToS3);
 		});
@@ -48,15 +48,15 @@ describe("cloud emulator service", () => {
 		it("should call create if emulator credentials not present", async () => {
 			const injector = createTestInjector();
 			let hasCalledCloudRequestService = false;
-			injector.resolve("cloudRequestService").call = (options: ICloudRequestOptions) => {
+			injector.resolve("nsCloudRequestService").call = (options: ICloudRequestOptions) => {
 				hasCalledCloudRequestService = true;
 				assert.deepEqual(options.method, HTTP_METHODS.POST, "create is not called upon missing credentials");
 
 				return emulatorCredentials;
 			};
 
-			const cloudEmulatorService: ICloudEmulatorService = injector.resolve(CloudEmulatorService);
-			await cloudEmulatorService.deployApp(filePath, platform);
+			const nsCloudEmulatorService: ICloudEmulatorService = injector.resolve(CloudEmulatorService);
+			await nsCloudEmulatorService.deployApp(filePath, platform);
 
 			assert.isTrue(hasCalledCloudRequestService);
 		});
@@ -67,15 +67,15 @@ describe("cloud emulator service", () => {
 			injector.resolve("fs").readJson = () => ({
 				[platform]: emulatorCredentials
 			});
-			injector.resolve("cloudRequestService").call = (options: ICloudRequestOptions) => {
+			injector.resolve("nsCloudRequestService").call = (options: ICloudRequestOptions) => {
 				hasCalledCloudRequestService = true;
 				assert.deepEqual(options.method, HTTP_METHODS.PUT, "update is not called upon existing credentials");
 
 				return emulatorCredentials;
 			};
 
-			const cloudEmulatorService: ICloudEmulatorService = injector.resolve(CloudEmulatorService);
-			await cloudEmulatorService.deployApp(filePath, platform);
+			const nsCloudEmulatorService: ICloudEmulatorService = injector.resolve(CloudEmulatorService);
+			await nsCloudEmulatorService.deployApp(filePath, platform);
 
 			assert.isTrue(hasCalledCloudRequestService);
 		});


### PR DESCRIPTION
As each extension may register its own services, it is possible more than one extension to register services with the same name.
This will lead to unexpected behavior at runtime.
Currently it happened with `applicationService` and `gitService` which also exist in `nativescript-starter-kits`.
In order to resolve the issue rename all services by prefixing them with `nsCloud`.

NOTE: This is a breaking change for all publicly exposed services. Here's a map of the breaking changes:

### Breaking changes:
* `applicationService` has been renamed to `nsCloudApplicationService`
* `authenticationService` has been renamed to `nsCloudAuthenticationService`
* `cloudBuildService` has been renamed to `nsCloudBuildService`
* `cloudCodesignService` has been renamed to `nsCloudCodesignService`
* `cloudEmulatorLauncher` has been renamed to `nsCloudEmulatorLauncher`
* `cloudPublishService` has been renamed to `nsCloudPublishService`
* `userService` has been renamed to `nsCloudUserService`