### PR TITLE
Download EULA to temp file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "querystring": "0.2.0",
     "semver": "5.3.0",
     "simple-plist": "0.2.1",
+    "temp": "0.8.3",
     "uuid": "3.0.1",
     "xml-escape": "1.1.0"
   }

--- a/test/services/eula-service.ts
+++ b/test/services/eula-service.ts
@@ -52,7 +52,8 @@ describe("eulaService", () => {
 			getFileShasum: async (fileName: string, options?: { algorithm?: string, encoding?: string }): Promise<string> => testInfo.eulaFileShasum,
 			getFsStats: (path: string): IFsStats => (<any>{
 				mtime: { getTime: (): number => testInfo.eulaLastModifiedTimeInEpoch || 0 }
-			})
+			}),
+			copyFile: (sourceFileName: string, destinationFileName: string): void => undefined
 		});
 
 		testInjector.register("options", {


### PR DESCRIPTION
The EULA should be downloaded to a temp file as the `pipeTo` option of httpClient.httpRequest` immediately creates the file or overwrites it.
In case the download fails, we'll end up with 0KB EULA, which will trigger many incorrect behaviors on our side.
In order to fix this - move the EULA to its location after full download is finished.