### PR TITLE
Add the application id to the tmp git folder

### DIFF
--- a/lib/commands/build-command-helper.ts
+++ b/lib/commands/build-command-helper.ts
@@ -32,7 +32,7 @@ export class BuildCommandHelper implements IBuildCommandHelper {
 		}
 
 		const pathToProvision = this.$options.provision ? path.resolve(this.$options.provision) : "";
-		const projectSettings: IProjectSettings = {
+		const projectSettings: INSCloudProjectSettings = {
 			nativescriptData,
 			projectDir: this.$projectData.projectDir,
 			projectId: this.$projectData.projectId,

--- a/lib/definitions/cloud-build-service.d.ts
+++ b/lib/definitions/cloud-build-service.d.ts
@@ -64,7 +64,7 @@ interface IBuildData {
 	/**
 	 * Describes the current project - project dir, application identifier, name and nativescript data.
 	 */
-	projectSettings: IProjectSettings;
+	projectSettings: INSCloudProjectSettings;
 	/**
 	 * The mobile platform for which the application should be built: Android or iOS.
 	 */
@@ -89,7 +89,7 @@ interface IBuildData {
 interface ICloudBuildService extends ICloudOperationService {
 	/**
 	 * Builds the specified application in the cloud and returns information about the whole build process.
-	 * @param {IProjectSettings} projectSettings Describes the current project - project dir, application identifier, name and nativescript data.
+	 * @param {INSCloudProjectSettings} projectSettings Describes the current project - project dir, application identifier, name and nativescript data.
 	 * @param {string} platform The mobile platform for which the application should be built: Android or iOS.
 	 * @param {string} buildConfiguration The build configuration - Debug or Release.
 	 * @param {string} accountId the account which will be charged for the build.
@@ -97,7 +97,7 @@ interface ICloudBuildService extends ICloudOperationService {
 	 * @param {IIOSBuildData} iOSBuildData iOS specific information for the build.
 	 * @returns {Promise<IBuildResultData>} Information about the build process. It is returned only on successful build. In case the build fails, the Promise is rejected with the server information.
 	 */
-	build(projectSettings: IProjectSettings,
+	build(projectSettings: INSCloudProjectSettings,
 		platform: string,
 		buildConfiguration: string,
 		accountId: string,
@@ -149,7 +149,7 @@ interface IItmsPlistOptions {
 /**
  * Describes the project settings required for different operations.
  */
-interface IProjectSettings extends IEnvOptions {
+interface INSCloudProjectSettings extends IEnvOptions {
 	/**
 	 * The directory where the project is located. This should be the path to the directory where application's package.json is located.
 	 */

--- a/lib/definitions/git-service.d.ts
+++ b/lib/definitions/git-service.d.ts
@@ -1,5 +1,5 @@
 interface IGitService {
-	gitPushChanges(projectDir: string, remoteUrl: IRemoteUrl, codeCommitCredential: ICodeCommitCredentials, repositoryState?: IRepositoryState): Promise<void>;
+	gitPushChanges(projectSettings: INSCloudProjectSettings, remoteUrl: IRemoteUrl, codeCommitCredential: ICodeCommitCredentials, repositoryState?: IRepositoryState): Promise<void>;
 }
 
 interface IRepositoryState {

--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -55,7 +55,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		return this.getServerOperationOutputDirectory(options);
 	}
 
-	public async build(projectSettings: IProjectSettings,
+	public async build(projectSettings: INSCloudProjectSettings,
 		platform: string,
 		buildConfiguration: string,
 		accountId: string,
@@ -72,7 +72,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		}
 	}
 
-	public async executeBuild(projectSettings: IProjectSettings,
+	public async executeBuild(projectSettings: INSCloudProjectSettings,
 		platform: string,
 		buildConfiguration: string,
 		buildId: string,
@@ -264,7 +264,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 	}
 
 	private async prepareProject(buildId: string,
-		projectSettings: IProjectSettings,
+		projectSettings: INSCloudProjectSettings,
 		platform: string,
 		buildConfiguration: string,
 		iOSBuildData: IIOSBuildData): Promise<void> {
@@ -310,7 +310,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 	}
 
 	private async prepareBuildRequest(buildId: string,
-		projectSettings: IProjectSettings,
+		projectSettings: INSCloudProjectSettings,
 		platform: string,
 		buildConfiguration: string,
 		buildCredentials: IBuildCredentialResponse,
@@ -319,7 +319,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		this.emitStepChanged(buildId, constants.BUILD_STEP_NAME.UPLOAD, constants.BUILD_STEP_PROGRESS.START);
 		let buildFiles;
 		try {
-			await this.$nsCloudGitService.gitPushChanges(projectSettings.projectDir,
+			await this.$nsCloudGitService.gitPushChanges(projectSettings,
 				{ httpRemoteUrl: buildCredentials.codeCommit.cloneUrlHttp },
 				buildCredentials.codeCommit.credentials,
 				{ isNewRepository: buildCredentials.codeCommit.isNewRepository });
@@ -387,7 +387,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		return cert.replace(/\s/g, "").substr(constants.CRYPTO.CERTIFICATE_HEADER.length).slice(0, -constants.CRYPTO.CERTIFICATE_FOOTER.length);
 	}
 
-	private async getAndroidBuildProperties(projectSettings: IProjectSettings,
+	private async getAndroidBuildProperties(projectSettings: INSCloudProjectSettings,
 		buildProps: any,
 		amazonStorageEntriesData: IAmazonStorageEntryData[],
 		androidBuildData?: IAndroidBuildData): Promise<any> {
@@ -410,7 +410,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		return buildProps;
 	}
 
-	private async getiOSBuildProperties(projectSettings: IProjectSettings,
+	private async getiOSBuildProperties(projectSettings: INSCloudProjectSettings,
 		buildProps: any,
 		amazonStorageEntriesData: IAmazonStorageEntryData[],
 		iOSBuildData: IIOSBuildData): Promise<any> {


### PR DESCRIPTION
We need to add the application identifier to the name of the temp git
folder. With the current name we have problem when the user changes the
application identifier of the project. When we create the temp git folder
we set the cloud remote to code commit repo X. After the app identifier is
changed we try to add again cloud remote to code commit repo Y in the same
temp git folder. This operation fails and we default to zip upload.