### PR TITLE
Fix getUserAvatar method

### DIFF
--- a/README.md
+++ b/README.md
@@ -913,7 +913,7 @@ Usage:
 ```JavaScript
 const tns = require("nativescript");
 
-tns.nsCloudUserService.hasUser()
+tns.nsCloudUserService.getUserAvatar()
 	.then(userAvatar => console.log(userAvatar));
 ```
 

--- a/lib/services/user-service.ts
+++ b/lib/services/user-service.ts
@@ -5,8 +5,8 @@ export class UserService implements IUserService {
 	private userData: IUserData;
 	private userInfoDirectory: string;
 
-	private get $nsCloudAccountsService(): IAccountsCloudService {
-		return this.$injector.resolve("nsCloudAccountsService");
+	private get $nsCloudAccountsCloudService(): IAccountsCloudService {
+		return this.$injector.resolve("nsCloudAccountsCloudService");
 	}
 
 	constructor(private $injector: IInjector,
@@ -78,7 +78,7 @@ export class UserService implements IUserService {
 			return null;
 		}
 
-		const userInfo = await this.$nsCloudAccountsService.getUserInfo();
+		const userInfo = await this.$nsCloudAccountsCloudService.getUserInfo();
 		return userInfo.externalAvatarUrl;
 	}
 


### PR DESCRIPTION
The `getUserAvatar` method is failing as it is using incorrect injected dependency - nsCloudAccountsService. The correct one is `nsCloudAccountsCloudService`.
Fix README as well - the example is incorrect as it does not call the `getUserAvatar` method.