### PR TITLE
Throw meaningful error if apple service is unavailable.

### DIFF
--- a/lib/services/cloud-codesign-service.ts
+++ b/lib/services/cloud-codesign-service.ts
@@ -56,7 +56,7 @@ export class CloudCodesignService extends CloudService implements ICloudCodesign
 	}
 
 	private validateParameteres(codesignData: ICodesignData,
-		projectDir: string) : void {
+		projectDir: string): void {
 		if (!codesignData || !codesignData.username || !codesignData.password) {
 			this.$errors.failWithoutHelp(`Codesign failed. Reason is missing code sign data. Apple Id and Apple Id password are required..`);
 		}
@@ -89,7 +89,13 @@ export class CloudCodesignService extends CloudService implements ICloudCodesign
 
 		if (!codesignResult.buildItems || !codesignResult.buildItems.length) {
 			// Something failed.
-			const err: any = new Error(`Codesign failed. Reason is: ${codesignResult.errors}.`);
+			let errText = codesignResult.errors || "";
+			if (errText.indexOf("403 Forbidden") > -1) {
+				this.$logger.trace(`Codesign errors: ${errText}`);
+				errText = "The Code Signing Assistance service is temporary unavailable. Please try again later.";
+			}
+
+			const err = <IStdError>new Error(`Codesign failed. Reason is: ${errText}.`);
 			err.stderr = codesignResult.stderr;
 			throw err;
 		}


### PR DESCRIPTION
Reported in this issue - https://github.com/NativeScript/sidekick-feedback/issues/92

It looks like apple is having sporadic maintenance on the developer site and some of our users are experiencing strange 403 Forbidden error. Seem like fastline are having similar issue as well - https://github.com/fastlane/fastlane/issues/10323
