### PR TITLE
Interpolate app.gradle file prior to build

### DIFF
--- a/lib/commands/build-command-helper.ts
+++ b/lib/commands/build-command-helper.ts
@@ -37,7 +37,7 @@ export class BuildCommandHelper implements IBuildCommandHelper {
 			projectDir: this.$projectData.projectDir,
 			projectId: this.$projectData.projectId,
 			projectName: this.$projectData.projectName,
-			bundle: this.$options.bundle,
+			bundle: !!this.$options.bundle,
 			clean: this.$options.clean,
 			env: this.$options.env
 		};
@@ -83,7 +83,7 @@ export class BuildCommandHelper implements IBuildCommandHelper {
 				buildForDevice: true,
 				clean: this.$options.clean,
 				teamId: this.$options.teamId,
-				bundle: this.$options.bundle,
+				bundle: !!this.$options.bundle,
 				device: this.$options.device,
 				projectDir: this.$options.path,
 				provision: this.$options.provision,


### PR DESCRIPTION
If we do not interpolate the data in the project's `app.gradle` file, one is bound to end up with a `__PACKAGE__` application indentifier upon multiple subsequent cloud builds.

Ping @rosen-vladimirov 