### PR TITLE
Respect proxyAuthenticationRequired property during upload

### DIFF
--- a/lib/services/upload-service.ts
+++ b/lib/services/upload-service.ts
@@ -38,7 +38,7 @@ export class UploadService implements IUploadService {
 		try {
 			await this.$httpClient.httpRequest(requestOpts);
 		} catch (err) {
-			this.$errors.failWithoutHelp(`Error while uploading ${filePathOrContent} to S3. Errors is:`, err.message);
+			this.$errors.fail({ formatStr: `Error while uploading ${filePathOrContent} to S3. Errors is: ${err.message}`, proxyAuthenticationRequired: err.proxyAuthenticationRequired, suppressCommandHelp: true });
 		}
 
 		return preSignedUrlData && preSignedUrlData.publicDownloadUrl;


### PR DESCRIPTION
In case the upload to S3 fails, we dismiss the real error object. However, it may contain additional property: proxyAuthenticationRequired, which shows the caller that the cause of the failure is a proxy, requiring authentication.
So pass the value to the `errors.fail` method, which will construct correct error object.

NOTE: Merge after https://github.com/telerik/mobile-cli-lib/pull/1033 (transpilation will fail before that)