### PR TITLE
Enable building with custom CLI version

### DIFF
--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -589,7 +589,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		if (!runtimeVersion && coreModulesVersion) {
 			// no runtime added. Let's find out which one we need based on the tns-core-modules.
 			if (semver.valid(coreModulesVersion)) {
-				runtimeVersion = await this.getLatestMatchingVersion(runtimePackageName, this.getVersionRangeWithTilde(coreModulesVersion));
+				runtimeVersion = process.env.TNS_CLI_CLOUD_VERSION || await this.getLatestMatchingVersion(runtimePackageName, this.getVersionRangeWithTilde(coreModulesVersion));
 			} else if (semver.validRange(coreModulesVersion)) {
 				// In case tns-core-modules in package.json are referred as `~x.x.x` - this is not a valid version, but is valid range.
 				runtimeVersion = await this.getLatestMatchingVersion(runtimePackageName, coreModulesVersion);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {


### PR DESCRIPTION
Enable setting a custom value for CLI version during cloud builds.
Said value is set through an environment variable, named `TNS_CLI_CLOUD_VERSION`

Ping @rosen-vladimirov @nadyaA 