### PR TITLE
Add command flags to change global server config

### DIFF
--- a/lib/cloud-options-provider.ts
+++ b/lib/cloud-options-provider.ts
@@ -4,8 +4,10 @@ export class CloudOptionsProvider implements ICloudOptionsProvider {
 	public get dashedOptions() {
 		return {
 			accountId: { type: OptionType.String },
+			apiVersion: { type: OptionType.String },
 			local: { type: OptionType.Boolean },
-			track: { type: OptionType.String, default: DEFAULT_ANDROID_PUBLISH_TRACK }
+			serverProto: { type: OptionType.String },
+			track: { type: OptionType.String, default: DEFAULT_ANDROID_PUBLISH_TRACK },
 		};
 	}
 }

--- a/lib/commands/config/config-apply.ts
+++ b/lib/commands/config/config-apply.ts
@@ -1,12 +1,19 @@
 export class ConfigApplyCommand implements ICommand {
-	constructor(private $nsCloudServerConfigManager: IServerConfigManager,
-		private $stringParameterBuilder: IStringParameterBuilder) { }
-
 	public allowedParameters: ICommandParameter[] = [this.$stringParameterBuilder.createMandatoryParameter("Configuration name cannot be empty.")];
+
+	public get dashedOptions() {
+		return this.$nsCloudOptionsProvider.dashedOptions;
+	}
+
+	constructor(private $nsCloudOptionsProvider: ICloudOptionsProvider,
+		private $nsCloudServerConfigManager: IServerConfigManager,
+		private $options: ICloudOptions,
+		private $stringParameterBuilder: IStringParameterBuilder) { }
 
 	public async execute(args: string[]): Promise<void> {
 		const configurationName = args[0];
-		this.$nsCloudServerConfigManager.applyConfig(configurationName);
+		const globalServerConfig = { apiVersion: this.$options.apiVersion, serverProto: this.$options.serverProto };
+		this.$nsCloudServerConfigManager.applyConfig(configurationName, null, globalServerConfig);
 		this.$nsCloudServerConfigManager.printConfigData();
 	}
 }

--- a/lib/commands/config/config-apply.ts
+++ b/lib/commands/config/config-apply.ts
@@ -12,7 +12,7 @@ export class ConfigApplyCommand implements ICommand {
 
 	public async execute(args: string[]): Promise<void> {
 		const configurationName = args[0];
-		const globalServerConfig = { apiVersion: this.$options.apiVersion, serverProto: this.$options.serverProto };
+		const globalServerConfig: IServerConfigBase = { apiVersion: this.$options.apiVersion, serverProto: this.$options.serverProto };
 		this.$nsCloudServerConfigManager.applyConfig(configurationName, null, globalServerConfig);
 		this.$nsCloudServerConfigManager.printConfigData();
 	}

--- a/lib/commands/config/config-set.ts
+++ b/lib/commands/config/config-set.ts
@@ -12,8 +12,8 @@ export class ConfigApplyCommand implements ICommand {
 
 	public async execute(args: string[]): Promise<void> {
 		const configurationFile = args[0];
-		const globalServerConfig = { apiVersion: this.$options.apiVersion, serverProto: this.$options.serverProto };
-		this.$nsCloudServerConfigManager.applyConfig(null, { configurationFile: configurationFile }, globalServerConfig);
+		const globalServerConfig: IServerConfigBase = { apiVersion: this.$options.apiVersion, serverProto: this.$options.serverProto };
+		this.$nsCloudServerConfigManager.applyConfig(null, { configurationFile }, globalServerConfig);
 		this.$nsCloudServerConfigManager.printConfigData();
 	}
 }

--- a/lib/commands/config/config-set.ts
+++ b/lib/commands/config/config-set.ts
@@ -1,12 +1,19 @@
 export class ConfigApplyCommand implements ICommand {
-	constructor(private $nsCloudServerConfigManager: IServerConfigManager,
-		private $stringParameterBuilder: IStringParameterBuilder) { }
-
 	public allowedParameters: ICommandParameter[] = [this.$stringParameterBuilder.createMandatoryParameter("You must specify path to configuration file.")];
+
+	public get dashedOptions() {
+		return this.$nsCloudOptionsProvider.dashedOptions;
+	}
+
+	constructor(private $nsCloudOptionsProvider: ICloudOptionsProvider,
+		private $nsCloudServerConfigManager: IServerConfigManager,
+		private $options: ICloudOptions,
+		private $stringParameterBuilder: IStringParameterBuilder) { }
 
 	public async execute(args: string[]): Promise<void> {
 		const configurationFile = args[0];
-		this.$nsCloudServerConfigManager.applyConfig(null, { configurationFile: configurationFile });
+		const globalServerConfig = { apiVersion: this.$options.apiVersion, serverProto: this.$options.serverProto };
+		this.$nsCloudServerConfigManager.applyConfig(null, { configurationFile: configurationFile }, globalServerConfig);
 		this.$nsCloudServerConfigManager.printConfigData();
 	}
 }

--- a/lib/definitions/cloud-options.d.ts
+++ b/lib/definitions/cloud-options.d.ts
@@ -3,7 +3,9 @@
  */
 interface ICloudOptions extends IOptions {
 	accountId: string;
+	apiVersion: string;
 	local: boolean;
+	serverProto: string;
 	track: string;
 }
 

--- a/lib/definitions/server-config-manager.d.ts
+++ b/lib/definitions/server-config-manager.d.ts
@@ -9,28 +9,31 @@ interface IServerConfigManager {
 	 * Applies specific configuration and saves it in config.json
 	 * @param {string} configName The name of the configuration to be applied.
 	 * @param optional {IConfigOptions} options The config options.
+	 * @param optional {IServerConfigBase} globalServerConfig The global server configuration which will
+	 * be used when changing the configuration. This parameter will override the default global configuration.
 	 * @returns {void}
 	 */
-	applyConfig(configName: string, options?: IConfigOptions): void;
+	applyConfig(configName: string, options?: IConfigOptions, globalServerConfig?: IServerConfigBase): void;
 
 	getCurrentConfigData(): IServerConfig;
 
 	printConfigData(): void;
 }
 
-interface IServerConfig {
+interface IServerConfigBase {
 	apiVersion?: string;
-	domainName: string;
 	serverProto?: string;
+}
+
+interface IServerConfig extends IServerConfigBase {
+	domainName: string;
 	stage?: string;
 	cloudServices: IDictionary<ICloudServiceConfig>;
 	[index: string]: string | IDictionary<ICloudServiceConfig>;
 }
 
-interface ICloudServiceConfig {
-	apiVersion?: string;
+interface ICloudServiceConfig extends IServerConfigBase {
 	fullHostName?: string;
-	serverProto?: string;
 	subdomain?: string;
 	[index: string]: string;
 }

--- a/lib/server-config-manager.ts
+++ b/lib/server-config-manager.ts
@@ -32,7 +32,7 @@ export class ServerConfigManager implements IServerConfigManager {
 
 	public printConfigData(): void {
 		const config = this.getCurrentConfigData();
-		console.log(JSON.stringify(config, null, "  "));
+		console.log(JSON.stringify(config, null, 2));
 	}
 
 	public getCurrentConfigData(): IServerConfig {

--- a/lib/server-config-manager.ts
+++ b/lib/server-config-manager.ts
@@ -23,16 +23,16 @@ export class ServerConfigManager implements IServerConfigManager {
 		this.applyConfig("production");
 	}
 
-	public applyConfig(configName: string, options?: IConfigOptions): void {
+	public applyConfig(configName: string, options?: IConfigOptions, globalServerConfig?: IServerConfigBase): void {
 		const baseConfig = this.loadConfig(ServerConfigManager.BASE_CONFIG_FILE_NAME);
 		const newConfig = this.loadConfig(`${ServerConfigManager.CONFIG_FILE_NAME}-${configName}`, options);
-		this.mergeConfig(baseConfig, newConfig);
+		this.mergeConfig(baseConfig, newConfig, globalServerConfig);
 		this.saveConfig(baseConfig, ServerConfigManager.CONFIG_FILE_NAME);
 	}
 
 	public printConfigData(): void {
 		const config = this.getCurrentConfigData();
-		console.log(config);
+		console.log(JSON.stringify(config, null, "  "));
 	}
 
 	public getCurrentConfigData(): IServerConfig {
@@ -65,8 +65,12 @@ export class ServerConfigManager implements IServerConfigManager {
 		return this.$fs.writeJson(configFileName, configNoFunctions);
 	}
 
-	private mergeConfig(config: any, mergeFrom: IServerConfig): void {
+	private mergeConfig(config: any, mergeFrom: IServerConfig, globalServerConfig?: IServerConfigBase): void {
 		_.extend(config, mergeFrom);
+		if (globalServerConfig) {
+			const filteredGlobalConfig = _.omitBy(globalServerConfig, _.isUndefined);
+			_.extend(config, filteredGlobalConfig);
+		}
 	}
 }
 


### PR DESCRIPTION
Each server PR build produces test dns record with api version in the
following format -> `pr<pr-number>`. To make the development cycle easier
we can add --apiVersion flag to the config apply/set commands which will
override the default apiVersion of the provided configuration. This way
when we want to use a specific server PR we can just execute `tns config
apply test --apiVersion pr<pr-number>`.