### PR TITLE
Fix using custom CLI version in the cloud

### DIFF
--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -589,7 +589,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		if (!runtimeVersion && coreModulesVersion) {
 			// no runtime added. Let's find out which one we need based on the tns-core-modules.
 			if (semver.valid(coreModulesVersion)) {
-				runtimeVersion = process.env.TNS_CLI_CLOUD_VERSION || await this.getLatestMatchingVersion(runtimePackageName, this.getVersionRangeWithTilde(coreModulesVersion));
+				runtimeVersion = await this.getLatestMatchingVersion(runtimePackageName, this.getVersionRangeWithTilde(coreModulesVersion));
 			} else if (semver.validRange(coreModulesVersion)) {
 				// In case tns-core-modules in package.json are referred as `~x.x.x` - this is not a valid version, but is valid range.
 				runtimeVersion = await this.getLatestMatchingVersion(runtimePackageName, coreModulesVersion);
@@ -601,7 +601,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 
 	private async getCliVersion(runtimeVersion: string): Promise<string> {
 		try {
-			const latestMatchingVersion = await this.getLatestMatchingVersion("nativescript", this.getVersionRangeWithTilde(runtimeVersion));
+			const latestMatchingVersion = process.env.TNS_CLI_CLOUD_VERSION || await this.getLatestMatchingVersion("nativescript", this.getVersionRangeWithTilde(runtimeVersion));
 			return latestMatchingVersion || CloudBuildService.DEFAULT_VERSION;
 		} catch (err) {
 			this.$logger.trace(`Unable to get information about CLI versions. Error is: ${err.message}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {


### PR DESCRIPTION
Currently the env variable `TNS_CLI_CLOUD_VERSION` is used to set the runtime version in the cloud, not the CLI version. Fix the code, so the variable will be used as it has been intended - to set the CLI version in the cloud.