### PR TITLE
Throw correct error when requests to our server are blocked

### DIFF
--- a/lib/services/server/server-services-proxy.ts
+++ b/lib/services/server/server-services-proxy.ts
@@ -57,9 +57,13 @@ export class ServerServicesProxy implements IServerServicesProxy {
 
 		this.$logger.debug("%s (%s %s) returned %d", finalUrlPath, options.method, options.urlPath, response.response.statusCode);
 
-		const resultValue: T = options.accept === CONTENT_TYPES.APPLICATION_JSON ? JSON.parse(response.body) : response.body;
-
-		return resultValue;
+		try {
+			const resultValue: T = options.accept === CONTENT_TYPES.APPLICATION_JSON ? JSON.parse(response.body) : response.body;
+			return resultValue;
+		} catch (err) {
+			this.$logger.trace("Error while trying to parse body: ", err);
+			throw new Error(`Server returned unexpected response: ${response.body}`);
+		}
 	}
 
 	public getServiceAddress(serviceName: string): string {


### PR DESCRIPTION
In case requests to our server are blocked by proxy, in most of the cases html is returned instead of JSON.
In this case we do not show correct error, but fail with `Unexpected token < in JSON at position 0`
This generates support as users are unable to understand the real cause of the problem.
In order to give them more information, throw error with the returned body.