### PR TITLE
Fix getting runtime and cli versions for cloud builds

### DIFF
--- a/lib/definitions/version-service.d.ts
+++ b/lib/definitions/version-service.d.ts
@@ -1,5 +1,26 @@
+/**
+ * Describes methods used to get different versions of components.
+ */
 interface IVersionService {
+	/**
+	 * Gives information for CLI version that should be used in the cloud.
+	 * @param {string} runtimeVersion The runtime version based on which CLI version will be calculated.
+	 * @returns {Promise<string>} CLI version that should be used in the cloud.
+	 */
 	getCliVersion(runtimeVersion: string): Promise<string>;
-	getRuntimeVersion(platform: string, nativescriptData: any, coreModulesVersion: string): Promise<string>;
+
+	/**
+	 * Gives information for the version of a runtime used in the project.
+	 * @param {string} projectDir The directory of the project.
+	 * @param {string} platform The platform (iOS or Android).
+	 * @returns {Promise<string>} The version of the runtime.
+	 */
+	getProjectRuntimeVersion(projectDir: string, platform: string): Promise<string>;
+
+	/**
+	 * Gives information for the version of the tns-core-modules package used in the project.
+	 * @param {string} projectDir The directory of the project.
+	 * @returns {string} The version of the tns-core-modules package used in the dependencies section of the project.
+	 */
 	getCoreModulesVersion(projectDir: string): string;
 }

--- a/lib/definitions/version-service.d.ts
+++ b/lib/definitions/version-service.d.ts
@@ -16,11 +16,4 @@ interface IVersionService {
 	 * @returns {Promise<string>} The version of the runtime.
 	 */
 	getProjectRuntimeVersion(projectDir: string, platform: string): Promise<string>;
-
-	/**
-	 * Gives information for the version of the tns-core-modules package used in the project.
-	 * @param {string} projectDir The directory of the project.
-	 * @returns {string} The version of the tns-core-modules package used in the dependencies section of the project.
-	 */
-	getCoreModulesVersion(projectDir: string): string;
 }

--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -380,8 +380,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		}
 
 		this.emitStepChanged(settings.buildId, constants.BUILD_STEP_NAME.UPLOAD, constants.BUILD_STEP_PROGRESS.END);
-		const coreModulesVersion = this.$nsCloudVersionService.getCoreModulesVersion(settings.projectSettings.projectDir);
-		const runtimeVersion = await this.$nsCloudVersionService.getRuntimeVersion(settings.platform, settings.projectSettings.nativescriptData, coreModulesVersion);
+		const runtimeVersion = await this.$nsCloudVersionService.getProjectRuntimeVersion(settings.projectSettings.projectDir, settings.platform);
 		const cliVersion = await this.$nsCloudVersionService.getCliVersion(runtimeVersion);
 		const sanitizedProjectName = this.$projectHelper.sanitizeName(settings.projectSettings.projectName);
 

--- a/lib/services/version-service.ts
+++ b/lib/services/version-service.ts
@@ -1,9 +1,7 @@
-import { join } from "path";
 import * as semver from "semver";
 
 export class VersionService implements IVersionService {
-	constructor(private $fs: IFileSystem,
-		private $httpClient: Server.IHttpClient,
+	constructor(private $httpClient: Server.IHttpClient,
 		private $logger: ILogger,
 		private $projectDataService: IProjectDataService) { }
 
@@ -11,18 +9,12 @@ export class VersionService implements IVersionService {
 		try {
 			const latestMatchingVersion = process.env.TNS_CLI_CLOUD_VERSION || await this.getLatestMatchingVersion("nativescript", this.getVersionRangeWithTilde(runtimeVersion));
 			if (!latestMatchingVersion) {
-				throw new Error(`Cannot find matching CLI version based on runtime version ${runtimeVersion}`);
+				throw new Error("Cannot find CLI versions.");
 			}
 
 			return latestMatchingVersion;
 		} catch (err) {
-			this.$logger.trace(`Unable to get information about CLI versions. Error is: ${err.message}`);
-			if (!semver.valid(runtimeVersion)) {
-				// In case the runtime version is not a valid semver version, we cannot determine CLI version.
-				throw new Error("Unable to determine CLI version for cloud build.");
-			}
-
-			return `${semver.major(runtimeVersion)}.${semver.minor(runtimeVersion)}.0`;
+			throw new Error(`Unable to determine CLI version for cloud build based on project's runtime version: ${runtimeVersion}. Error is: ${err.message}`);
 		}
 	}
 
@@ -35,10 +27,6 @@ export class VersionService implements IVersionService {
 		}
 
 		return runtimeVersion;
-	}
-
-	public getCoreModulesVersion(projectDir: string): string {
-		return this.$fs.readJson(join(projectDir, "package.json")).dependencies["tns-core-modules"];
 	}
 
 	private async getLatestMatchingVersion(packageName: string, range: string): Promise<string> {

--- a/lib/services/version-service.ts
+++ b/lib/services/version-service.ts
@@ -2,41 +2,42 @@ import { join } from "path";
 import * as semver from "semver";
 
 export class VersionService implements IVersionService {
-	private static DEFAULT_CLI_VERSION = "3.0.0";
-
 	constructor(private $fs: IFileSystem,
 		private $httpClient: Server.IHttpClient,
-		private $logger: ILogger) { }
+		private $logger: ILogger,
+		private $projectDataService: IProjectDataService) { }
 
 	public async getCliVersion(runtimeVersion: string): Promise<string> {
 		try {
 			const latestMatchingVersion = process.env.TNS_CLI_CLOUD_VERSION || await this.getLatestMatchingVersion("nativescript", this.getVersionRangeWithTilde(runtimeVersion));
-			return latestMatchingVersion || VersionService.DEFAULT_CLI_VERSION;
+			if (!latestMatchingVersion) {
+				throw new Error(`Cannot find matching CLI version based on runtime version ${runtimeVersion}`);
+			}
+
+			return latestMatchingVersion;
 		} catch (err) {
 			this.$logger.trace(`Unable to get information about CLI versions. Error is: ${err.message}`);
+			if (!semver.valid(runtimeVersion)) {
+				// In case the runtime version is not a valid semver version, we cannot determine CLI version.
+				throw new Error("Unable to determine CLI version for cloud build.");
+			}
+
 			return `${semver.major(runtimeVersion)}.${semver.minor(runtimeVersion)}.0`;
 		}
 	}
 
-	public async getRuntimeVersion(platform: string, nativescriptData: any, coreModulesVersion: string): Promise<string> {
+	public async getProjectRuntimeVersion(projectDir: string, platform: string, ): Promise<string> {
 		const runtimePackageName = `tns-${platform.toLowerCase()}`;
-		let runtimeVersion = nativescriptData && nativescriptData[runtimePackageName] && nativescriptData[runtimePackageName].version;
-		if (!runtimeVersion && coreModulesVersion) {
-			// no runtime added. Let's find out which one we need based on the tns-core-modules.
-			if (semver.valid(coreModulesVersion)) {
-				runtimeVersion = await this.getLatestMatchingVersion(runtimePackageName, this.getVersionRangeWithTilde(coreModulesVersion));
-			} else if (semver.validRange(coreModulesVersion)) {
-				// In case tns-core-modules in package.json are referred as `~x.x.x` - this is not a valid version, but is valid range.
-				runtimeVersion = await this.getLatestMatchingVersion(runtimePackageName, coreModulesVersion);
-			}
+		const runtimeVersion = this.$projectDataService.getNSValue(projectDir, `${runtimePackageName}.version`);
+
+		if (!runtimeVersion) {
+			throw new Error(`Unable to find runtime version for package ${runtimePackageName}.`);
 		}
 
-		return runtimeVersion || VersionService.DEFAULT_CLI_VERSION;
+		return runtimeVersion;
 	}
 
 	public getCoreModulesVersion(projectDir: string): string {
-		// HACK just for this version. After that we'll have UI for getting runtime version.
-		// Until then, use the coreModulesVersion.
 		return this.$fs.readJson(join(projectDir, "package.json")).dependencies["tns-core-modules"];
 	}
 
@@ -51,13 +52,17 @@ export class VersionService implements IVersionService {
 
 	private async getVersionsFromNpm(packageName: string): Promise<string[]> {
 		try {
-			const response = await this.$httpClient.httpRequest(`http://registry.npmjs.org/${packageName}`);
-			const versions = _.keys(JSON.parse(response.body).versions);
-			return versions;
+			const packageData = await this.getPackageDataFromNpm(packageName);
+			return _.keys(packageData.versions);
 		} catch (err) {
 			this.$logger.trace(`Unable to get versions of ${packageName} from npm. Error is: ${err.message}.`);
 			return [];
 		}
+	}
+
+	private async getPackageDataFromNpm(packageName: string): Promise<IDictionary<any>> {
+		const response = await this.$httpClient.httpRequest(`http://registry.npmjs.org/${packageName}`);
+		return JSON.parse(response.body);
 	}
 
 	private getVersionRangeWithTilde(versionString: string): string {

--- a/test/services/version-service.ts
+++ b/test/services/version-service.ts
@@ -1,0 +1,194 @@
+import { VersionService } from "../../lib/services/version-service";
+import { Yok } from "mobile-cli-lib/yok";
+import { assert } from "chai";
+import { join } from "path";
+
+const TNS_CLI_CLOUD_VERSION_ORIGINAL = process.env.TNS_CLI_CLOUD_VERSION;
+describe("versionService", () => {
+	const createTestInjector = (): IInjector => {
+		const testInjector = new Yok();
+		testInjector.register("logger", {
+			trace: (formatStr?: any, ...args: any[]): void => (undefined)
+		});
+		testInjector.register("fs", {});
+		testInjector.register("httpClient", {});
+		testInjector.register("projectDataService", {});
+		return testInjector;
+	};
+
+	let isHttpRequestCalled = false;
+	afterEach(() => {
+		process.env.TNS_CLI_CLOUD_VERSION = TNS_CLI_CLOUD_VERSION_ORIGINAL;
+	});
+
+	beforeEach(() => {
+		isHttpRequestCalled = false;
+		process.env.TNS_CLI_CLOUD_VERSION = "";
+	});
+
+	describe("getCliVersion", () => {
+		const cliVersion = "5.0.0";
+		it("returns process.env.TNS_CLI_CLOUD_VERSION when it is set", async () => {
+			const testInjector = createTestInjector();
+			process.env.TNS_CLI_CLOUD_VERSION = cliVersion;
+
+			const versionService = testInjector.resolve<IVersionService>(VersionService);
+			const actualCliVersion = await versionService.getCliVersion(null);
+			assert.equal(actualCliVersion, cliVersion);
+		});
+
+		const testData: any[] = [
+			{
+				runtimeVersion: "5.0.0",
+				expectedCliVersion: "5.0.2"
+			},
+			{
+				runtimeVersion: "5.0.2",
+				expectedCliVersion: "5.0.2"
+			},
+			{
+				runtimeVersion: "5.0.5",
+				expectedCliVersion: "5.0.2"
+			},
+			{
+				runtimeVersion: "5.1.5",
+				expectedCliVersion: "5.1.0"
+			},
+			{
+				runtimeVersion: "4.1.0",
+				expectedCliVersion: "4.1.0"
+			},
+			{
+				runtimeVersion: "4.1.8",
+				expectedCliVersion: "4.1.0"
+			}
+		];
+
+		const mockHttpRequest = (testInjector: IInjector, body: IDictionary<any>, error?: Error) => {
+			const httpClient = testInjector.resolve<Server.IHttpClient>("httpClient");
+
+			httpClient.httpRequest = async (url: string): Promise<any> => {
+				isHttpRequestCalled = true;
+				assert.equal(url, "http://registry.npmjs.org/nativescript");
+				if (error) {
+					throw error;
+				}
+
+				return { body: JSON.stringify(body) };
+
+			};
+		};
+
+		_.each(testData, ({ runtimeVersion, expectedCliVersion }) => {
+			it(`returns correct CLI version, based on runtime version, input: ${runtimeVersion}, expectedOutput: ${expectedCliVersion}`, async () => {
+				const testInjector = createTestInjector();
+				const body = {
+					versions: {
+						"1.0.0": {},
+						"5.0.0": {},
+						"5.0.1": {},
+						"5.0.2": {},
+						"5.1.0": {},
+						"6.0.0": {},
+					}
+				};
+
+				mockHttpRequest(testInjector, body);
+				const versionService = testInjector.resolve<IVersionService>(VersionService);
+				const actualCliVersion = await versionService.getCliVersion(runtimeVersion);
+				assert.equal(actualCliVersion, expectedCliVersion);
+				assert.isTrue(isHttpRequestCalled, "An http request to registry.npmjs.org should have been made in order to get data for CLI.");
+			});
+		});
+
+		it("fails when unable to determine CLI version as runtime version is not valid semver version", async () => {
+			const testInjector = createTestInjector();
+			const body = {
+				versions: {
+					"5.0.0": {}
+				}
+			};
+
+			mockHttpRequest(testInjector, body);
+
+			const versionService = testInjector.resolve<IVersionService>(VersionService);
+			await assert.isRejected(versionService.getCliVersion("some invalid version"), "Unable to determine CLI version for cloud build.");
+			assert.isFalse(isHttpRequestCalled, "An http request to registry.npmjs.org should have NOT been made.");
+		});
+
+		it("returns version based on runtime when http requests fail", async () => {
+			const testInjector = createTestInjector();
+			mockHttpRequest(testInjector, null, new Error("Http request fails."));
+
+			const versionService = testInjector.resolve<IVersionService>(VersionService);
+			assert.deepEqual(await versionService.getCliVersion("1.2.3"), "1.2.0");
+			assert.isTrue(isHttpRequestCalled, "An http request to registry.npmjs.org should have been made in order to get data for CLI.");
+		});
+	});
+
+	describe("getCoreModulesVersion", () => {
+		it("returns the version from package.json", async () => {
+			const testInjector = createTestInjector();
+			const fs = testInjector.resolve<IFileSystem>("fs");
+			const projectDir = "projectDir";
+			let isReadJsonCalled = false;
+			const tnsCoreModulesVersion = "3.0.0";
+			fs.readJson = (filename: string, encoding?: string): any => {
+				isReadJsonCalled = true;
+				assert.equal(join(projectDir, "package.json"), filename, "fs.readJson must be called with path to package.json");
+				return {
+					dependencies: {
+						"tns-core-modules": "3.0.0"
+					}
+				};
+			};
+
+			const versionService = testInjector.resolve<IVersionService>(VersionService);
+			const actualTnsCoreModulesVersion = await versionService.getCoreModulesVersion(projectDir);
+			assert.equal(actualTnsCoreModulesVersion, tnsCoreModulesVersion);
+			assert.isTrue(isReadJsonCalled, "fs.readJson should have been called.");
+		});
+	});
+
+	describe("getProjectRuntimeVersion", () => {
+		it("returns the version from package.json", async () => {
+			const testInjector = createTestInjector();
+			const projectDataService = testInjector.resolve<IProjectDataService>("projectDataService");
+			const projectDir = "project dir";
+			const platform = "platform";
+			const runtimeVersion = "3.0.0";
+			let isGetNSValueCalled = false;
+			projectDataService.getNSValue = (projDir: string, propertyName: string): any => {
+				isGetNSValueCalled = true;
+				assert.equal(projDir, projectDir, "getNSValue should be called with the projectDir passed to getProjectRuntimeVersion");
+				assert.equal(propertyName, `tns-${platform}.version`);
+
+				return runtimeVersion;
+			};
+
+			const versionService = testInjector.resolve<IVersionService>(VersionService);
+			const actualRuntimeVersion = await versionService.getProjectRuntimeVersion(projectDir, platform);
+			assert.equal(actualRuntimeVersion, runtimeVersion);
+			assert.isTrue(isGetNSValueCalled, "getNSValue must be called");
+		});
+
+		it("fails when runtime is not added to package.json", async () => {
+			const testInjector = createTestInjector();
+			const projectDataService = testInjector.resolve<IProjectDataService>("projectDataService");
+			const projectDir = "project dir";
+			const platform = "platform";
+			let isGetNSValueCalled = false;
+			projectDataService.getNSValue = (projDir: string, propertyName: string): any => {
+				isGetNSValueCalled = true;
+				assert.equal(projDir, projectDir, "getNSValue should be called with the projectDir passed to getProjectRuntimeVersion");
+				assert.equal(propertyName, `tns-${platform}.version`);
+
+				return null;
+			};
+
+			const versionService = testInjector.resolve<IVersionService>(VersionService);
+			await assert.isRejected(versionService.getProjectRuntimeVersion(projectDir, platform), `Unable to find runtime version for package tns-${platform}.`);
+			assert.isTrue(isGetNSValueCalled, "getNSValue must be called");
+		});
+	});
+});


### PR DESCRIPTION
Fix getting runtime and cli versions for cloud builds by reading the
package.json of the project just before sending the request. Currently
we are relying on the nativescriptData passed by the caller, but in case
this is the first build for this platform, the nativeScriptData contains
only the id of the project. However, before sending the build request,
we are adding the platform, so the package.json contains the required
version of the runtime. So instead of using some logic to determine the
runtime version, just read the package.json.
Also remove the default fallbacks for CLI and runtime (3.0.0). From now
on, whenever we are unable to find version that should be used in the
cloud, an error will be raised.
This fixes the case when the first cloud build is executed with version
3.0.x of CLI and runtime, when tns-core-modules version in package.json
is next.
This also fixes the case when first and second cloud build are executed
with different CLI and runtime - when you have CLI 3.4.x, but you are
trying to build a project (for a first time), that has tns-core-modules
3.3.x as dependency, the first cloud build will be executed with CLI
3.3.x and runtime 3.3.x, while the second one will be with 3.4.x

Add tests for versionService.