### PR TITLE
Add new subscription expiration properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -986,7 +986,7 @@ Definition:
  */
 getMyAccounts(): Promise<IAccount[]>
 ```
-Detailed description of each parameter can be found [here](./lib/definitions/accounts-service.d.ts).
+Detailed description of each parameter can be found [here](./lib/definitions/server/server-accounts-service.d.ts).
 </br>
 
 Usage:
@@ -1010,7 +1010,7 @@ Definition:
  */
 getUsageInfo(accountId: string): Promise<IUsageInfo[]>;
 ```
-Detailed description of each parameter can be found [here](./lib/definitions/accounts-service.d.ts).
+Detailed description of each parameter can be found [here](./lib/definitions/server/server-accounts-service.d.ts).
 </br>
 
 Usage:

--- a/lib/commands/account/usage.ts
+++ b/lib/commands/account/usage.ts
@@ -35,7 +35,9 @@ export class UsageCommand extends AccountCommandBase implements ICommand {
 					remaining: u.unlimited ? u.allowedUsage : u.allowedUsage - u.usage,
 					unlimited: !!u.unlimited,
 					editionType: u.editionType,
-					licenseExpiration: u.licenseExpiration,
+					licenseExpiration: u.licenseExpiration, // This is here only for backwards compatibility.
+					licenseExpirationDate: u.licenseExpirationDate,
+					resetDate: u.resetDate,
 					licenseType: u.licenseType
 				};
 
@@ -48,7 +50,7 @@ export class UsageCommand extends AccountCommandBase implements ICommand {
 			output = stringifyWithIndentation(groupedUsage);
 		} else {
 			const tables = _.map(groupedUsage, (g, feature) => {
-				return createTable([`${feature} performed`, `${feature} remaining`, "License Expiration", "License Type", "Edition Type"], g.map(u => {
+				return createTable([`${feature} performed`, `${feature} remaining`, "Reset Date", "License Expiration", "License Type", "Edition Type"], g.map(u => {
 					const result = [u.performed.toString()];
 					if (u.unlimited) {
 						result.push(UNLIMITED);
@@ -57,7 +59,7 @@ export class UsageCommand extends AccountCommandBase implements ICommand {
 						result.push(remainingUsage.toString());
 					}
 
-					return result.concat(new Date(u.licenseExpiration).toDateString(), u.licenseType, u.editionType);
+					return result.concat(this.toPrettyDate(u.resetDate), this.toPrettyDate(u.licenseExpirationDate), u.licenseType, u.editionType);
 				}));
 			});
 
@@ -65,6 +67,10 @@ export class UsageCommand extends AccountCommandBase implements ICommand {
 		}
 
 		this.$logger.out(output);
+	}
+
+	private toPrettyDate(date: string): string {
+		return new Date(date).toDateString();
 	}
 }
 

--- a/lib/definitions/server/server-accounts-service.d.ts
+++ b/lib/definitions/server/server-accounts-service.d.ts
@@ -46,9 +46,21 @@ interface IUsageInfoBase {
 	unlimited: boolean;
 
 	/**
-	 * When the license expires.
+	 * When the monthly usage will be reset. This property is here for backwards compatibility.
 	 */
 	licenseExpiration: string;
+
+	/**
+	 * When the license of the user expires. This is not necessary to be one month. We have complimentary
+	 * licenses with custom license expiration. Also our users can buy N monthly licenses and the
+	 * license expiration date will be N * 1 month.
+	 */
+	licenseExpirationDate: string;
+
+	/**
+	 * When the monthly usage will be reset.
+	 */
+	resetDate: string;
 
 	/**
 	 * The type of the license.


### PR DESCRIPTION
The current `licenseExpiration` property represents when the cloud builds
usage will be rest. For the monthly licenses this reset date is the same
as the license expiration. But we don't have only monthly licenses. We
have complimentary licenses with custom expiration date, business and
enterprise licenses which have yearly expiration date.
That's why our server now returns 2 new properties in the usage info.
`licenseExpirationDate` which is the real license expiration date and
`resetDate` which is the monthly usage reset date. The `licenseExpiration`
property is not deleted for backwards compatibility.