### PR TITLE
Introduce cloud run|deploy commands 

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -57,6 +57,10 @@ $injector.requireCommand("logout", path.join(__dirname, "commands", "logout"));
 $injector.requireCommand("user", path.join(__dirname, "commands", "user"));
 $injector.requireCommand("kill-server", path.join(__dirname, "commands", "kill-server"));
 
+$injector.requireCommand(["deploy|cloud", "cloud|deploy"], path.join(__dirname, "commands", "cloud-deploy"));
+$injector.requireCommand(["run|cloud|*all", "cloud|run|*all"], path.join(__dirname, "commands", "cloud-run"));
+$injector.requireCommand(["run|cloud|ios", "cloud|run|ios"], path.join(__dirname, "commands", "cloud-run"));
+$injector.requireCommand(["run|cloud|android", "cloud|run|android"], path.join(__dirname, "commands", "cloud-run"));
 $injector.requireCommand(["cloud|build", "build|cloud"], path.join(__dirname, "commands", "cloud-build"));
 $injector.requireCommand(["cloud|codesign", "codesign|cloud"], path.join(__dirname, "commands", "cloud-codesign"));
 $injector.requireCommand("cloud|publish|android", path.join(__dirname, "commands", "cloud-publish"));

--- a/lib/commands/build-command-helper.ts
+++ b/lib/commands/build-command-helper.ts
@@ -18,6 +18,17 @@ export class BuildCommandHelper implements IBuildCommandHelper {
 		this.$projectData.initializeProjectData();
 	}
 
+	public async buildPlatform(platform: string, buildConfig: IBuildConfig, projectData: IProjectData): Promise<string> {
+		const buildData = this.getCloudBuildData(platform);
+		buildData.iOSBuildData.buildForDevice = buildConfig.buildForDevice;
+		const buildResultData = await this.$nsCloudBuildService.build(buildData.projectSettings,
+			buildData.platform, buildData.buildConfiguration,
+			this.$options.accountId,
+			buildData.androidBuildData,
+			buildData.iOSBuildData);
+		return buildResultData.outputFilePath;
+	}
+
 	public getCloudBuildData(platformArg: string): IBuildData {
 		const platform = this.$mobileHelper.validatePlatformName(platformArg);
 		this.$logger.info(`Executing cloud build with platform: ${platform}.`);

--- a/lib/commands/bundle-validator-base-command.ts
+++ b/lib/commands/bundle-validator-base-command.ts
@@ -1,0 +1,20 @@
+const bundleValidatorHelperName = "bundleValidatorHelper";
+
+/**
+ * Remove this class after CLI 4.0.0 - it exists for backwards compatibility only.
+ */
+export abstract class BundleValidatorBaseCommand {
+	protected get $bundleValidatorHelper(): IBundleValidatorHelper {
+		try {
+			return this.$injector.resolve(bundleValidatorHelperName);
+		} catch (e) {
+			this.$logger.trace(`Unable to resolve ${bundleValidatorHelperName}, probably using and older version of CLI. Will default.`, e);
+			return {
+				validate: () => { /* Mock */ }
+			};
+		}
+	}
+
+	constructor(private $injector: IInjector,
+		private $logger: ILogger) { }
+}

--- a/lib/commands/cloud-build.ts
+++ b/lib/commands/cloud-build.ts
@@ -1,18 +1,22 @@
-export class CloudBuildCommand implements ICommand {
+import { BundleValidatorBaseCommand } from "./bundle-validator-base-command";
+
+export class CloudBuildCommand extends BundleValidatorBaseCommand implements ICommand {
 	public allowedParameters: ICommandParameter[];
 
 	public get dashedOptions() {
 		return this.$nsCloudOptionsProvider.dashedOptions;
 	}
 
-	constructor(private $nsCloudEulaCommandHelper: IEulaCommandHelper,
+	constructor($injector: IInjector,
+		$logger: ILogger,
+		private $nsCloudEulaCommandHelper: IEulaCommandHelper,
 		private $errors: IErrors,
 		private $nsCloudBuildCommandHelper: IBuildCommandHelper,
 		private $nsCloudBuildService: ICloudBuildService,
 		private $nsCloudOptionsProvider: ICloudOptionsProvider,
 		private $options: ICloudOptions,
-		private $projectData: IProjectData,
-		private $bundleValidatorHelper: IBundleValidatorHelper) {
+		private $projectData: IProjectData) {
+		super($injector, $logger);
 		this.$projectData.initializeProjectData();
 	}
 

--- a/lib/commands/cloud-deploy.ts
+++ b/lib/commands/cloud-deploy.ts
@@ -1,11 +1,15 @@
-export class CloudDeploy implements ICommand {
+import { BundleValidatorBaseCommand } from "./bundle-validator-base-command";
+
+export class CloudDeploy extends BundleValidatorBaseCommand implements ICommand {
 	public allowedParameters: ICommandParameter[];
 
 	public get dashedOptions() {
 		return this.$nsCloudOptionsProvider.dashedOptions;
 	}
 
-	constructor(private $platformService: IPlatformService,
+	constructor($injector: IInjector,
+		$logger: ILogger,
+		private $platformService: IPlatformService,
 		private $nsCloudEulaCommandHelper: IEulaCommandHelper,
 		private $errors: IErrors,
 		private $deployCommandHelper: IDeployCommandHelper,
@@ -13,8 +17,8 @@ export class CloudDeploy implements ICommand {
 		private $nsCloudBuildService: ICloudBuildService,
 		private $nsCloudOptionsProvider: ICloudOptionsProvider,
 		private $options: ICloudOptions,
-		private $projectData: IProjectData,
-		private $bundleValidatorHelper: IBundleValidatorHelper) {
+		private $projectData: IProjectData) {
+		super($injector, $logger);
 		this.$projectData.initializeProjectData();
 	}
 

--- a/lib/commands/cloud-run.ts
+++ b/lib/commands/cloud-run.ts
@@ -1,0 +1,81 @@
+export class CloudRunCommand implements ICommand {
+	public allowedParameters: ICommandParameter[];
+
+	public get dashedOptions() {
+		return this.$nsCloudOptionsProvider.dashedOptions;
+	}
+
+	public platform: string;
+	constructor(private $liveSyncCommandHelper: ILiveSyncCommandHelper,
+		private $nsCloudEulaCommandHelper: IEulaCommandHelper,
+		private $nsCloudBuildService: ICloudBuildService,
+		private $nsCloudBuildCommandHelper: IBuildCommandHelper,
+		private $errors: IErrors,
+		private $nsCloudOptionsProvider: ICloudOptionsProvider,
+		private $projectData: IProjectData) {
+		this.$projectData.initializeProjectData();
+	}
+
+	public async execute(args: string[]): Promise<void> {
+		return this.$liveSyncCommandHelper.executeCommandLiveSync(this.platform, {
+			getOutputDirectory: this.$nsCloudBuildService.getServerOperationOutputDirectory.bind(this.$nsCloudBuildService),
+			buildPlatform: this.$nsCloudBuildCommandHelper.buildPlatform.bind(this.$nsCloudBuildCommandHelper)
+		});
+	}
+
+	public async canExecute(args: string[]): Promise<boolean> {
+		await this.$nsCloudEulaCommandHelper.ensureEulaIsAccepted();
+
+		if (args.length) {
+			this.$errors.fail("This input is not valid for the run command");
+		}
+
+		this.$liveSyncCommandHelper.validatePlatform(this.platform);
+
+		return true;
+	}
+}
+
+$injector.registerCommand(["run|cloud|*all", "cloud|run|*all"], CloudRunCommand);
+
+export class CloudRunIosCommand extends CloudRunCommand implements ICommand {
+	public allowedParameters: ICommandParameter[] = [];
+	public get platform(): string {
+		return this.$devicePlatformsConstants.iOS;
+	}
+
+	constructor($liveSyncCommandHelper: ILiveSyncCommandHelper,
+		$nsCloudEulaCommandHelper: IEulaCommandHelper,
+		$errors: IErrors,
+		$nsCloudBuildCommandHelper: IBuildCommandHelper,
+		$nsCloudBuildService: ICloudBuildService,
+		$nsCloudOptionsProvider: ICloudOptionsProvider,
+		$devicesService: Mobile.IDevicesService,
+		$projectData: IProjectData,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) {
+		super($liveSyncCommandHelper, $nsCloudEulaCommandHelper, $nsCloudBuildService, $nsCloudBuildCommandHelper, $errors, $nsCloudOptionsProvider, $projectData);
+	}
+}
+
+$injector.registerCommand(["run|cloud|ios", "cloud|run|ios"], CloudRunIosCommand);
+
+export class CloudRunAndroidCommand extends CloudRunCommand implements ICommand {
+	public allowedParameters: ICommandParameter[] = [];
+	public get platform(): string {
+		return this.$devicePlatformsConstants.Android;
+	}
+
+	constructor($liveSyncCommandHelper: ILiveSyncCommandHelper,
+		$nsCloudEulaCommandHelper: IEulaCommandHelper,
+		$errors: IErrors,
+		$nsCloudBuildCommandHelper: IBuildCommandHelper,
+		$nsCloudBuildService: ICloudBuildService,
+		$nsCloudOptionsProvider: ICloudOptionsProvider,
+		$devicesService: Mobile.IDevicesService,
+		$projectData: IProjectData,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) {
+		super($liveSyncCommandHelper, $nsCloudEulaCommandHelper, $nsCloudBuildService, $nsCloudBuildCommandHelper, $errors, $nsCloudOptionsProvider, $projectData);
+	}
+}
+
+$injector.registerCommand(["run|cloud|android", "cloud|run|android"], CloudRunAndroidCommand);

--- a/lib/commands/cloud-run.ts
+++ b/lib/commands/cloud-run.ts
@@ -27,7 +27,7 @@ export class CloudRunCommand implements ICommand {
 		await this.$nsCloudEulaCommandHelper.ensureEulaIsAccepted();
 
 		if (args.length) {
-			this.$errors.fail("This input is not valid for the run command");
+			this.$errors.fail("This input is not valid for the cloud run command");
 		}
 
 		this.$liveSyncCommandHelper.validatePlatform(this.platform);

--- a/lib/definitions/build-command-helper.d.ts
+++ b/lib/definitions/build-command-helper.d.ts
@@ -1,7 +1,7 @@
 /**
  * Describes helper that can be used for building.
  */
-interface IBuildCommandHelper {
+interface IBuildCommandHelper extends IBuildPlatformAction {
 	/**
 	 * Retrieves data needed to perform a cloud build.
 	 * @param {string} platformArg The mobile platform for which the application should be built: Android or iOS.

--- a/lib/definitions/cloud-build-service.d.ts
+++ b/lib/definitions/cloud-build-service.d.ts
@@ -280,7 +280,7 @@ interface IIOSBuildData extends IBuildForDevice {
 }
 
 /**
- * Here only for backwards compatibility.
+ * Here only for backwards compatibility. Deleting this will require a major version change as it is used in NativeScript Sidekick.
  */
-interface ICloudBuildOutputDirectoryOptions extends ICloudServerOutputDirectoryOptions {
+interface ICloudBuildOutputDirectoryOptions extends IOutputDirectoryOptions {
 }

--- a/lib/definitions/cloud-service.d.ts
+++ b/lib/definitions/cloud-service.d.ts
@@ -29,21 +29,6 @@ interface IServerStatus {
 }
 
 /**
- * Describes options that can be passed in order to specify the exact location of the built package.
- */
-interface ICloudServerOutputDirectoryOptions extends IPlatform {
-	/**
-	 * Directory where the project is located.
-	 */
-	projectDir: string;
-
-	/**
-	 * Whether the build is for emulator or not.
-	 */
-	emulator?: boolean;
-}
-
-/**
  * Describes the result from server operation.
  */
 interface IServerResult {
@@ -79,8 +64,8 @@ interface IServerItem extends IServerItemBase, IPlatform {
 interface ICloudOperationService {
 	/**
 	 * Returns the path to the directory where the server request output may be found.
-	 * @param {ICloudServerOutputDirectoryOptions} options Options that are used to determine the build output directory.
+	 * @param {IOutputDirectoryOptions} options Options that are used to determine the build output directory.
 	 * @returns {string} The build output directory.
 	 */
-	getServerOperationOutputDirectory(options: ICloudServerOutputDirectoryOptions): string;
+	getServerOperationOutputDirectory(options: IOutputDirectoryOptions): string;
 }

--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -40,7 +40,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		super($fs, $httpClient, $logger);
 	}
 
-	public getServerOperationOutputDirectory(options: ICloudServerOutputDirectoryOptions): string {
+	public getServerOperationOutputDirectory(options: IOutputDirectoryOptions): string {
 		let result = path.join(options.projectDir, constants.CLOUD_TEMP_DIR_NAME, options.platform.toLowerCase());
 		if (this.$mobileHelper.isiOSPlatform(options.platform)) {
 			result = path.join(result, options.emulator ? constants.CLOUD_BUILD_DIRECTORY_NAMES.EMULATOR : constants.CLOUD_BUILD_DIRECTORY_NAMES.DEVICE);
@@ -50,7 +50,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 	}
 
 	/**
-	 * Here only for backwards compatibility.
+	 * Here only for backwards compatibility. Deleting this will require a major version change as it is used in NativeScript Sidekick.
 	 */
 	public getBuildOutputDirectory(options: ICloudBuildOutputDirectoryOptions): string {
 		return this.getServerOperationOutputDirectory(options);
@@ -540,7 +540,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		}
 	}
 
-	private async downloadServerResult(buildId: string, buildResult: IBuildServerResult, buildOutputOptions: ICloudServerOutputDirectoryOptions): Promise<string> {
+	private async downloadServerResult(buildId: string, buildResult: IBuildServerResult, buildOutputOptions: IOutputDirectoryOptions): Promise<string> {
 		this.emitStepChanged(buildId, constants.BUILD_STEP_NAME.DOWNLOAD, constants.BUILD_STEP_PROGRESS.START);
 		const targetFileNames = await super.downloadServerResults(buildResult, buildOutputOptions);
 		this.emitStepChanged(buildId, constants.BUILD_STEP_NAME.DOWNLOAD, constants.BUILD_STEP_PROGRESS.END);

--- a/lib/services/cloud-codesign-service.ts
+++ b/lib/services/cloud-codesign-service.ts
@@ -51,7 +51,7 @@ export class CloudCodesignService extends CloudService implements ICloudCodesign
 		return result;
 	}
 
-	public getServerOperationOutputDirectory(options: ICloudServerOutputDirectoryOptions): string {
+	public getServerOperationOutputDirectory(options: IOutputDirectoryOptions): string {
 		return path.join(options.projectDir, constants.CODESIGN_FILES_DIR_NAME, options.platform.toLowerCase());
 	}
 

--- a/lib/services/cloud-project-service.ts
+++ b/lib/services/cloud-project-service.ts
@@ -20,7 +20,7 @@ export class CloudProjectService extends CloudService implements ICloudProjectSe
 		super($fs, $httpClient, $logger);
 	}
 
-	public getServerOperationOutputDirectory(options: ICloudServerOutputDirectoryOptions): string {
+	public getServerOperationOutputDirectory(options: IOutputDirectoryOptions): string {
 		return path.join(options.projectDir, "cleanup-results");
 	}
 

--- a/lib/services/cloud-publish-service.ts
+++ b/lib/services/cloud-publish-service.ts
@@ -28,7 +28,7 @@ export class CloudPublishService extends CloudService implements ICloudPublishSe
 		super($fs, $httpClient, $logger);
 	}
 
-	public getServerOperationOutputDirectory(options: ICloudServerOutputDirectoryOptions): string {
+	public getServerOperationOutputDirectory(options: IOutputDirectoryOptions): string {
 		return "";
 	}
 

--- a/lib/services/cloud-service.ts
+++ b/lib/services/cloud-service.ts
@@ -15,7 +15,7 @@ export abstract class CloudService extends EventEmitter {
 	protected abstract getServerResults(serverResult: IBuildServerResult): IServerItem[];
 	protected abstract getServerLogs(logsUrl: string, buildId: string): Promise<void>;
 
-	public abstract getServerOperationOutputDirectory(options: ICloudServerOutputDirectoryOptions): string;
+	public abstract getServerOperationOutputDirectory(options: IOutputDirectoryOptions): string;
 
 	constructor(protected $fs: IFileSystem,
 		protected $httpClient: Server.IHttpClient,
@@ -73,7 +73,7 @@ export abstract class CloudService extends EventEmitter {
 			});
 	}
 
-	protected async downloadServerResults(serverResult: IBuildServerResult, serverOutputOptions: ICloudServerOutputDirectoryOptions): Promise<string[]> {
+	protected async downloadServerResults(serverResult: IBuildServerResult, serverOutputOptions: IOutputDirectoryOptions): Promise<string[]> {
 		const destinationDir = this.getServerOperationOutputDirectory(serverOutputOptions);
 		this.$fs.ensureDirectoryExists(destinationDir);
 


### PR DESCRIPTION
Introduce `cloud run|deploy` commands.
Designed to work as the conventional `run|deploy` commands but build in the cloud instead of locally.

**NB!** Remove latest commit before merging

Ping @rosen-vladimirov 