### PR TITLE
fix(kinvey): Set correct url for Kinvey Free EULA

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -114,7 +114,7 @@ export const ERROR_MESSAGES = {
 
 export class EulaConstants {
 	public static eulaUrl = "https://www.nativescript.org/nativescript-sidekick/eula";
-	public static kinveyEulaUrl = "https://www.nativescript.org/nativescript-sidekick/eula";
+	public static kinveyEulaUrl = "https://www.nativescript.org/nativescript-sidekick/kinvey-free-eula";
 	public static acceptedEulaHashKey = "acceptedEulaHash";
 	public static acceptedKinveyEulaHashKey = "acceptedKinveyEulaHash";
 	public static timeout = 60000;


### PR DESCRIPTION
Set the correct URL for Kinvey Free EULA. Currently it redirects to the Kinvey site, but it will be updated to contain a PDF file with the correct EULA