### PR TITLE
Respect runtime prereleases

### DIFF
--- a/lib/definitions/application-service.d.ts
+++ b/lib/definitions/application-service.d.ts
@@ -6,7 +6,7 @@ interface IApplicationBuildConfig extends IBuildConfig, IOptionalOutputPath, IPr
 /**
  * Describes settings that can be passed to shouldInstall method
  */
-interface IApplicationInstallConfig extends Mobile.IDeviceIdentifier, IProjectDir, IOptionalOutputPath { }
+interface IApplicationInstallConfig extends Mobile.IDeviceIdentifier, IProjectDir, IOptionalOutputPath, IRelease { }
 
 /**
  * Describes service which manages applications

--- a/lib/definitions/version-service.d.ts
+++ b/lib/definitions/version-service.d.ts
@@ -17,3 +17,18 @@ interface IVersionService {
 	 */
 	getProjectRuntimeVersion(projectDir: string, platform: string): Promise<string>;
 }
+
+/**
+ * Describes options that can be passed to getVersionRangeWithTilde method.
+ */
+interface IVersionRangeOptions {
+	/**
+	 * The version string - should be a valid semver string.
+	 */
+	versionString: string;
+
+	/**
+	 * Wether to respect the patch value of the versionString or just return 0 (e.g. latest patch).
+	 */
+	shouldRespectPatchVersion?: boolean;
+}

--- a/lib/services/application-service.ts
+++ b/lib/services/application-service.ts
@@ -16,7 +16,7 @@ export class ApplicationService implements IApplicationService {
 	public async shouldInstall(config: IApplicationInstallConfig): Promise<boolean> {
 		const projectData = this.$projectDataService.getProjectData(config.projectDir);
 		const device = await this.$devicesService.getDevice(config.deviceIdentifier);
-		return this.$platformService.shouldInstall(device, projectData, config.outputPath);
+		return this.$platformService.shouldInstall(device, projectData, config, config.outputPath);
 	}
 }
 

--- a/test/services/version-service.ts
+++ b/test/services/version-service.ts
@@ -41,6 +41,14 @@ describe("versionService", () => {
 				expectedCliVersion: "5.0.2"
 			},
 			{
+				runtimeVersion: "5.0.2-1",
+				expectedCliVersion: "5.0.2"
+			},
+			{
+				runtimeVersion: "5.0.3-1",
+				expectedCliVersion: "5.0.2"
+			},
+			{
 				runtimeVersion: "5.0.2",
 				expectedCliVersion: "5.0.2"
 			},
@@ -51,6 +59,22 @@ describe("versionService", () => {
 			{
 				runtimeVersion: "5.1.5",
 				expectedCliVersion: "5.1.0"
+			},
+			{
+				runtimeVersion: "7.0.0-0",
+				expectedCliVersion: "7.0.0-2"
+			},
+			{
+				runtimeVersion: "7.0.1-1",
+				expectedCliVersion: "7.0.1-2"
+			},
+			{
+				runtimeVersion: "7.0.1-5",
+				expectedCliVersion: "7.0.1-2"
+			},
+			{
+				runtimeVersion: "7.0.2-5",
+				expectedCliVersion: "7.0.0-2"
 			}
 		];
 
@@ -78,8 +102,13 @@ describe("versionService", () => {
 						"5.0.0": {},
 						"5.0.1": {},
 						"5.0.2": {},
+						"5.0.2-1": {},
 						"5.1.0": {},
 						"6.0.0": {},
+						"7.0.0-1": {},
+						"7.0.0-2": {},
+						"7.0.1-1": {},
+						"7.0.1-2": {},
 					}
 				};
 


### PR DESCRIPTION
In case the user has a prerelease of the runtime installed, use the latest prerelease of CLI during cloud builds.

Tested with:
```
> semver.maxSatisfying(versions, "~4.0.0-0")
"4.0.0-2018-03-07-10905"

> semver.maxSatisfying(versions, "~3.4.0-0")
"3.4.3"
```

In addition - pass `config` object to `shouldInstall` method.
**NB!** This is not breaking, because this method is currently unused.

Ping @rosen-vladimirov 