### PR TITLE
feat: Improve package.json, so CLI can detect this as extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,44 @@
     "temp": "0.8.3",
     "uuid": "3.0.1",
     "xml-escape": "1.1.0"
+  },
+  "keywords": [
+    "nativescript",
+    "nativescript:extension",
+    "nativescript-cloud",
+    "cloud",
+    "build"
+  ],
+  "nativescript": {
+    "commands": [
+      "accept|eula",
+      "account",
+      "account|features",
+      "account|usage",
+      "build|cloud",
+      "cloud|build",
+      "cloud|clean|workspace",
+      "cloud|codesign",
+      "cloud|deploy",
+      "cloud|lib|version",
+      "cloud|publish|android",
+      "cloud|publish|ios",
+      "cloud|run",
+      "cloud|run|android",
+      "cloud|run|ios",
+      "codesign|cloud",
+      "config",
+      "config|apply",
+      "config|reset",
+      "config|set",
+      "deploy|cloud",
+      "dev-login",
+      "login",
+      "logout",
+      "run|cloud",
+      "run|cloud|android",
+      "run|cloud|ios",
+      "user"
+    ]
   }
 }


### PR DESCRIPTION
In case extension is not installed, but user tries to use any command from it, CLI tries to find out in which extension the command is registered. It works by checking all packages in npm that have the `nativescript:extension` keyword.
After that it reads their package.json and searches for nativescript.commands array.
So prepare the `nativescript-cloud` by adding all commands to the correct place in package.json. Add required keyword and some addtional ones.