### PR TITLE
fix: Trying to build application with webpack produces incorrect local files

### DIFF
--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -287,9 +287,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 
 		const projectData = this.$projectDataService.getProjectData(projectSettings.projectDir);
 		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = {
-			// Set this option to false, so that the local prepare does not webpack in addition to the cloud one.
-			// TODO: Once we have a way to use webpack in livesync this value may need to change.
-			bundle: false,
+			bundle: projectSettings.bundle,
 			release: buildConfiguration && buildConfiguration.toLowerCase() === constants.CLOUD_BUILD_CONFIGURATIONS.RELEASE.toLowerCase()
 		};
 


### PR DESCRIPTION
When trying to build the application with webpack, the locally prepared files are incorrect. The problem is that the the bundle value is not passed to the prepare method - we have hardcoded false. This way the local files are prepared without webpack and the result application is not working.
Pass correct value, so the local files will be correct.