### PR TITLE
Use pre-signed download urls for cloud operations

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -6,6 +6,7 @@ $injector.require("nsCloudServerConfigManager", path.join(__dirname, "server-con
 $injector.require("nsCloudBuildOutputFilter", path.join(__dirname, "cloud-build-output-filter"));
 $injector.require("nsCloudDeviceEmulator", path.join(__dirname, "cloud-device-emulator"));
 $injector.require("nsCloudOptionsProvider", path.join(__dirname, "cloud-options-provider"));
+$injector.require("nsCloudBuildHelper", path.join(__dirname, "cloud-build-helper"));
 $injector.require("nsCloudBuildCommandHelper", path.join(__dirname, "commands", "build-command-helper"));
 $injector.require("nsCloudEulaCommandHelper", path.join(__dirname, "commands", "eula-command-helper"));
 
@@ -44,6 +45,7 @@ $injector.require("nsCloudDateTimeService", path.join(__dirname, "services", "da
 $injector.require("nsCloudGitService", path.join(__dirname, "services", "git-service"));
 $injector.require("nsCloudVersionService", path.join(__dirname, "services", "version-service"));
 $injector.require("nsCloudPolyfillService", path.join(__dirname, "services", "polyfill-service"));
+$injector.require("nsCloudBuildPropertiesService", path.join(__dirname, "services", "cloud-build-properties-service"));
 
 // Commands.
 $injector.requireCommand("config|*get", path.join(__dirname, "commands", "config", "config-get"));

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 $injector.require("nsCloudHttpServer", path.join(__dirname, "http-server"));
 $injector.require("nsCloudItmsServicesPlistHelper", path.join(__dirname, "itms-services-plist-helper"));
 $injector.require("nsCloudServerConfigManager", path.join(__dirname, "server-config-manager"));
-$injector.require("nsCloudBuildOutputFilter", path.join(__dirname, "cloud-build-output-filter"));
+$injector.require("nsCloudOutputFilter", path.join(__dirname, "cloud-output-filter"));
 $injector.require("nsCloudDeviceEmulator", path.join(__dirname, "cloud-device-emulator"));
 $injector.require("nsCloudOptionsProvider", path.join(__dirname, "cloud-options-provider"));
 $injector.require("nsCloudBuildHelper", path.join(__dirname, "cloud-build-helper"));

--- a/lib/cloud-build-helper.ts
+++ b/lib/cloud-build-helper.ts
@@ -1,0 +1,107 @@
+import * as constants from "./constants";
+
+import * as forge from "node-forge";
+import * as path from "path";
+import * as minimatch from "minimatch";
+
+const plist = require("simple-plist");
+
+export class CloudBuildHelper implements ICloudBuildHelper {
+	constructor(private $errors: IErrors,
+		private $fs: IFileSystem,
+		private $logger: ILogger) { }
+
+	public getProvisionType(provisionData: IMobileProvisionData): string {
+		let result = "";
+		if (provisionData.Entitlements['get-task-allow']) {
+			result = constants.PROVISION_TYPES.DEVELOPMENT;
+		} else {
+			result = constants.PROVISION_TYPES.ADHOC;
+		}
+
+		if (!provisionData.ProvisionedDevices || !provisionData.ProvisionedDevices.length) {
+			if (provisionData.ProvisionsAllDevices) {
+				result = constants.PROVISION_TYPES.ENTERPRISE;
+			} else {
+				result = constants.PROVISION_TYPES.APP_STORE;
+			}
+		}
+
+		return result;
+	}
+
+	public getCertificateInfo(certificatePath: string, certificatePassword: string): ICertificateInfo {
+		const certificateAbsolutePath = path.resolve(certificatePath);
+		const certificateContents: any = this.$fs.readFile(certificateAbsolutePath, { encoding: 'binary' });
+		const pkcs12Asn1 = forge.asn1.fromDer(certificateContents);
+		const pkcs12 = forge.pkcs12.pkcs12FromAsn1(pkcs12Asn1, false, certificatePassword);
+
+		for (let safeContens of pkcs12.safeContents) {
+			for (let safeBag of safeContens.safeBags) {
+				if (safeBag.attributes.localKeyId && safeBag.type === forge.pki.oids['certBag']) {
+					let issuer = safeBag.cert.issuer.getField(constants.CRYPTO.ORGANIZATION_FIELD_NAME);
+					return {
+						pemCert: forge.pki.certificateToPem(safeBag.cert),
+						organization: issuer && issuer.value,
+						validity: safeBag.cert.validity,
+						commonName: safeBag.cert.subject.getField(constants.CRYPTO.COMMON_NAME_FIELD_NAME).value,
+						friendlyName: _.head<string>(safeBag.attributes.friendlyName)
+					};
+				}
+			}
+		}
+
+		this.$errors.failWithoutHelp(`Could not read ${certificatePath}. Please make sure there is a certificate inside.`);
+	}
+
+	public isReleaseConfiguration(buildConfiguration: string): boolean {
+		return buildConfiguration.toLowerCase() === constants.CLOUD_BUILD_CONFIGURATIONS.RELEASE.toLowerCase();
+	}
+
+	public getMobileProvisionData(provisionPath: string): IMobileProvisionData {
+		const provisionText = this.$fs.readText(path.resolve(provisionPath));
+		const provisionPlistText = provisionText.substring(provisionText.indexOf(constants.CRYPTO.PLIST_HEADER), provisionText.indexOf(constants.CRYPTO.PLIST_FOOTER) + constants.CRYPTO.PLIST_FOOTER.length);
+		return plist.parse(provisionPlistText);
+	}
+
+	public async zipProject(projectDir: string): Promise<string> {
+		let tempDir = path.join(projectDir, constants.CLOUD_TEMP_DIR_NAME);
+		this.$fs.ensureDirectoryExists(tempDir);
+
+		let projectZipFile = path.join(tempDir, "Build.zip");
+		this.$fs.deleteFile(projectZipFile);
+
+		let files = this.getProjectFiles(projectDir, ["node_modules", "platforms", constants.CLOUD_TEMP_DIR_NAME, "**/.*"]);
+
+		await this.$fs.zipFiles(projectZipFile, files, p => this.getProjectRelativePath(p, projectDir));
+
+		return projectZipFile;
+	}
+
+	private getProjectFiles(projectFilesPath: string, excludedProjectDirsAndFiles?: string[], filter?: (filePath: string, stat: IFsStats) => boolean, opts?: any): string[] {
+		const projectFiles = this.$fs.enumerateFilesInDirectorySync(projectFilesPath, (filePath, stat) => {
+			const isFileExcluded = this.isFileExcluded(path.relative(projectFilesPath, filePath), excludedProjectDirsAndFiles);
+			const isFileFiltered = filter ? filter(filePath, stat) : false;
+			return !isFileExcluded && !isFileFiltered;
+		}, opts);
+
+		this.$logger.trace("getProjectFiles for cloud build: ", projectFiles);
+
+		return projectFiles;
+	}
+
+	private isFileExcluded(filePath: string, excludedProjectDirsAndFiles?: string[]): boolean {
+		return !!_.find(excludedProjectDirsAndFiles, (pattern) => minimatch(filePath, pattern, { nocase: true }));
+	}
+
+	private getProjectRelativePath(fullPath: string, projectDir: string): string {
+		projectDir = path.join(projectDir, path.sep);
+		if (!_.startsWith(fullPath, projectDir)) {
+			throw new Error("File is not part of the project.");
+		}
+
+		return fullPath.substring(projectDir.length);
+	}
+}
+
+$injector.register("nsCloudBuildHelper", CloudBuildHelper);

--- a/lib/cloud-output-filter.ts
+++ b/lib/cloud-output-filter.ts
@@ -1,6 +1,6 @@
 import { EOL } from "os";
 
-export class CloudBuildOutputFilter implements ICloudBuildOutputFilter {
+export class CloudOutputFilter implements ICloudOutputFilter {
 	public filter(logs: string): string {
 		let result = logs.replace(new RegExp("(\\\\r\\\\n)|(\\\\n)", "gm"), EOL) // Unescape new lines.
 			.replace(/(\\\\t)/g, "\t") // Unescape tabs.
@@ -24,4 +24,4 @@ export class CloudBuildOutputFilter implements ICloudBuildOutputFilter {
 	}
 }
 
-$injector.register("nsCloudBuildOutputFilter", CloudBuildOutputFilter);
+$injector.register("nsCloudOutputFilter", CloudOutputFilter);

--- a/lib/definitions/cloud-build-helper.d.ts
+++ b/lib/definitions/cloud-build-helper.d.ts
@@ -1,0 +1,7 @@
+declare interface ICloudBuildHelper {
+	getProvisionType(provisionData: IMobileProvisionData): string;
+	getCertificateInfo(certificatePath: string, certificatePassword: string): ICertificateInfo;
+	isReleaseConfiguration(buildConfiguration: string): boolean;
+	getMobileProvisionData(provisionPath: string): IMobileProvisionData;
+	zipProject(projectDir: string): Promise<string>;
+}

--- a/lib/definitions/cloud-build-output-filter.ts
+++ b/lib/definitions/cloud-build-output-filter.ts
@@ -1,3 +1,3 @@
-interface ICloudBuildOutputFilter {
+interface ICloudOutputFilter {
 	filter(data: string): string;
 }

--- a/lib/definitions/cloud-build-properties-service.d.ts
+++ b/lib/definitions/cloud-build-properties-service.d.ts
@@ -1,0 +1,17 @@
+declare interface ICloudBuildPropertiesService {
+	validateBuildProperties(platform: string,
+		buildConfiguration: string,
+		appId: string,
+		androidBuildData?: IAndroidBuildData,
+		iOSBuildData?: IIOSBuildData): Promise<void>;
+
+	getAndroidBuildProperties(projectSettings: INSCloudProjectSettings,
+		buildProps: any,
+		amazonStorageEntriesData: IAmazonStorageEntryData[],
+		androidBuildData?: IAndroidBuildData): Promise<any>;
+
+	getiOSBuildProperties(projectSettings: INSCloudProjectSettings,
+		buildProps: any,
+		amazonStorageEntriesData: IAmazonStorageEntryData[],
+		iOSBuildData: IIOSBuildData): Promise<any>
+}

--- a/lib/definitions/server/server-build-service.d.ts
+++ b/lib/definitions/server/server-build-service.d.ts
@@ -65,7 +65,6 @@ interface IBuildCredentialResponse {
 interface IAmazonStorageEntry {
 	uploadPreSignedUrl: string;
 	publicDownloadUrl: string;
-	s3Url: string;
 	fileName: string;
 }
 

--- a/lib/definitions/server/server-services.d.ts
+++ b/lib/definitions/server/server-services.d.ts
@@ -46,8 +46,6 @@ interface ICloudEmulatorResponse extends IPlatform {
 interface IPresignURLResponse {
 	uploadPreSignedUrl: string;
 	publicDownloadUrl: string;
-	s3Url: string;
-	sessionKey: string;
 }
 
 interface ICloudEmulatorKeys {

--- a/lib/services/cloud-build-properties-service.ts
+++ b/lib/services/cloud-build-properties-service.ts
@@ -1,0 +1,177 @@
+import * as constants from "../constants";
+
+import { EOL } from "os";
+
+export class CloudBuildPropertiesService implements ICloudBuildPropertiesService {
+	constructor(private $nsCloudBuildHelper: ICloudBuildHelper,
+		private $errors: IErrors,
+		private $fs: IFileSystem,
+		private $mobileHelper: Mobile.IMobileHelper) { }
+
+	public async validateBuildProperties(platform: string,
+		buildConfiguration: string,
+		appId: string,
+		androidBuildData?: IAndroidBuildData,
+		iOSBuildData?: IIOSBuildData): Promise<void> {
+		if (this.$mobileHelper.isAndroidPlatform(platform) && this.$nsCloudBuildHelper.isReleaseConfiguration(buildConfiguration)) {
+			if (!androidBuildData || !androidBuildData.pathToCertificate) {
+				this.$errors.failWithoutHelp("When building for Release configuration, you must specify valid Certificate and its password.");
+			}
+
+			if (!this.$fs.exists(androidBuildData.pathToCertificate)) {
+				this.$errors.failWithoutHelp(`The specified certificate: ${androidBuildData.pathToCertificate} does not exist. Verify the location is correct.`);
+			}
+
+			if (!androidBuildData.certificatePassword) {
+				this.$errors.failWithoutHelp(`No password specified for certificate ${androidBuildData.pathToCertificate}.`);
+			}
+
+			if (androidBuildData.certificatePassword.length < 6) {
+				this.$errors.failWithoutHelp("The password for Android certificate must be at least 6 characters long.");
+			}
+		} else if (this.$mobileHelper.isiOSPlatform(platform) && iOSBuildData.buildForDevice) {
+			if (!iOSBuildData || !iOSBuildData.pathToCertificate || !iOSBuildData.certificatePassword || !iOSBuildData.pathToProvision) {
+				this.$errors.failWithoutHelp("When building for iOS you must specify valid Mobile Provision, Certificate and its password.");
+			}
+
+			if (!this.$fs.exists(iOSBuildData.pathToCertificate)) {
+				this.$errors.failWithoutHelp(`The specified certificate: ${iOSBuildData.pathToCertificate} does not exist. Verify the location is correct.`);
+			}
+
+			if (!this.$fs.exists(iOSBuildData.pathToProvision)) {
+				this.$errors.failWithoutHelp(`The specified provision: ${iOSBuildData.pathToProvision} does not exist. Verify the location is correct.`);
+			}
+
+			const certInfo = this.$nsCloudBuildHelper.getCertificateInfo(iOSBuildData.pathToCertificate, iOSBuildData.certificatePassword);
+			const certBase64 = this.getCertificateBase64(certInfo.pemCert);
+			const provisionData = this.$nsCloudBuildHelper.getMobileProvisionData(iOSBuildData.pathToProvision);
+			const provisionCertificatesBase64 = _.map(provisionData.DeveloperCertificates, c => c.toString('base64'));
+			const now = Date.now();
+
+			let provisionAppId = provisionData.Entitlements['application-identifier'];
+			_.each(provisionData.ApplicationIdentifierPrefix, prefix => {
+				provisionAppId = provisionAppId.replace(`${prefix}.`, "");
+			});
+
+			let errors: string[] = [];
+
+			if (provisionAppId !== "*") {
+				let provisionIdentifierPattern = new RegExp(this.getRegexPattern(provisionAppId));
+				if (!provisionIdentifierPattern.test(appId)) {
+					errors.push(`The specified provision's (${iOSBuildData.pathToProvision}) application identifier (${provisionAppId}) doesn't match your project's application identifier (${appId}).`);
+				}
+			}
+
+			if (certInfo.organization !== constants.APPLE_INC) {
+				errors.push(`The specified certificate: ${iOSBuildData.pathToCertificate} is issued by an untrusted organization. Please provide a certificate issued by ${constants.APPLE_INC}`);
+			}
+
+			if (now > provisionData.ExpirationDate.getTime()) {
+				errors.push(`The specified provision: ${iOSBuildData.pathToProvision} has expired.`);
+			}
+
+			if (now < certInfo.validity.notBefore.getTime() || now > certInfo.validity.notAfter.getTime()) {
+				errors.push(`The specified certificate: ${iOSBuildData.pathToCertificate} has expired.`);
+			}
+
+			if (!_.includes(provisionCertificatesBase64, certBase64)) {
+				errors.push(`The specified provision: ${iOSBuildData.pathToProvision} does not include the specified certificate: ${iOSBuildData.pathToCertificate}. Please specify a different provision or certificate.`);
+			}
+
+			if (iOSBuildData.deviceIdentifier && !_.includes(provisionData.ProvisionedDevices, iOSBuildData.deviceIdentifier)) {
+				errors.push(`The specified provision: ${iOSBuildData.pathToProvision} does not include the specified device: ${iOSBuildData.deviceIdentifier}.`);
+			}
+
+			if (errors.length) {
+				this.$errors.failWithoutHelp(errors.join(EOL));
+			}
+		}
+	}
+
+	public async getAndroidBuildProperties(projectSettings: INSCloudProjectSettings,
+		buildProps: any,
+		amazonStorageEntriesData: IAmazonStorageEntryData[],
+		androidBuildData?: IAndroidBuildData): Promise<any> {
+
+		const buildConfiguration = buildProps.properties.buildConfiguration;
+
+		if (this.$nsCloudBuildHelper.isReleaseConfiguration(buildConfiguration)) {
+			const certificateData = _.find(amazonStorageEntriesData, amazonStorageEntryData => amazonStorageEntryData.filePath === androidBuildData.pathToCertificate);
+			buildProps.properties.keyStoreName = certificateData.fileName;
+			buildProps.properties.keyStoreAlias = this.$nsCloudBuildHelper.getCertificateInfo(androidBuildData.pathToCertificate, androidBuildData.certificatePassword).friendlyName;
+			buildProps.properties.keyStorePassword = androidBuildData.certificatePassword;
+			buildProps.properties.keyStoreAliasPassword = androidBuildData.certificatePassword;
+
+			buildProps.buildFiles.push({
+				disposition: certificateData.disposition,
+				sourceUri: certificateData.s3Url
+			});
+		}
+
+		return buildProps;
+	}
+
+	public async getiOSBuildProperties(projectSettings: INSCloudProjectSettings,
+		buildProps: any,
+		amazonStorageEntriesData: IAmazonStorageEntryData[],
+		iOSBuildData: IIOSBuildData): Promise<any> {
+
+		if (iOSBuildData.buildForDevice) {
+			const provisionData = this.$nsCloudBuildHelper.getMobileProvisionData(iOSBuildData.pathToProvision);
+			const certificateData = _.find(amazonStorageEntriesData, amazonStorageEntryData => amazonStorageEntryData.filePath === iOSBuildData.pathToCertificate);
+			const provisonData = _.find(amazonStorageEntriesData, amazonStorageEntryData => amazonStorageEntryData.filePath === iOSBuildData.pathToProvision);
+
+			buildProps.buildFiles.push(
+				{
+					sourceUri: certificateData.s3Url,
+					disposition: certificateData.disposition
+				},
+				{
+					sourceUri: provisonData.s3Url,
+					disposition: provisonData.disposition
+				}
+			);
+
+			buildProps.properties.certificatePassword = iOSBuildData.certificatePassword;
+			buildProps.properties.codeSigningIdentity = this.$nsCloudBuildHelper.getCertificateInfo(iOSBuildData.pathToCertificate, iOSBuildData.certificatePassword).commonName;
+
+			const cloudProvisionsData: any[] = [{
+				suffixId: "",
+				templateName: "PROVISION_",
+				identifier: provisionData.UUID,
+				isDefault: true,
+				fileName: provisonData.fileName,
+				appGroups: [],
+				provisionType: this.$nsCloudBuildHelper.getProvisionType(provisionData),
+				name: provisionData.Name
+			}];
+			buildProps.properties.mobileProvisionIdentifiers = JSON.stringify(cloudProvisionsData);
+			buildProps.properties.defaultMobileProvisionIdentifier = provisionData.UUID;
+		} else {
+			buildProps.properties.simulator = true;
+		}
+
+		return buildProps;
+	}
+
+	private getCertificateBase64(cert: string) {
+		return cert.replace(/\s/g, "").substr(constants.CRYPTO.CERTIFICATE_HEADER.length).slice(0, -constants.CRYPTO.CERTIFICATE_FOOTER.length);
+	}
+
+	private getRegexPattern(appIdentifier: string): string {
+		let starPlaceholder = "<!StarPlaceholder!>";
+		let escapedIdentifier = this.escape(this.stringReplaceAll(appIdentifier, "*", starPlaceholder));
+		let replacedIdentifier = this.stringReplaceAll(escapedIdentifier, starPlaceholder, ".*");
+		return "^" + replacedIdentifier + "$";
+	}
+
+	private escape(s: string): string {
+		return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+	}
+
+	private stringReplaceAll(inputString: string, find: any, replace: string): string {
+		return inputString.split(find).join(replace);
+	}
+}
+
+$injector.register("nsCloudBuildPropertiesService", CloudBuildPropertiesService);

--- a/lib/services/cloud-build-properties-service.ts
+++ b/lib/services/cloud-build-properties-service.ts
@@ -104,7 +104,7 @@ export class CloudBuildPropertiesService implements ICloudBuildPropertiesService
 
 			buildProps.buildFiles.push({
 				disposition: certificateData.disposition,
-				sourceUri: certificateData.s3Url
+				sourceUri: certificateData.publicDownloadUrl
 			});
 		}
 
@@ -123,11 +123,11 @@ export class CloudBuildPropertiesService implements ICloudBuildPropertiesService
 
 			buildProps.buildFiles.push(
 				{
-					sourceUri: certificateData.s3Url,
+					sourceUri: certificateData.publicDownloadUrl,
 					disposition: certificateData.disposition
 				},
 				{
-					sourceUri: provisonData.s3Url,
+					sourceUri: provisonData.publicDownloadUrl,
 					disposition: provisonData.disposition
 				}
 			);

--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -24,7 +24,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $nsCloudAccountsService: IAccountsService,
 		private $nsCloudServerBuildService: IServerBuildService,
-		private $nsCloudBuildOutputFilter: ICloudBuildOutputFilter,
+		private $nsCloudOutputFilter: ICloudOutputFilter,
 		private $nsCloudGitService: IGitService,
 		private $nsCloudItmsServicesPlistHelper: IItmsServicesPlistHelper,
 		private $nsCloudUploadService: IUploadService,
@@ -294,7 +294,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 			buildFiles = [
 				{
 					disposition,
-					sourceUri: preSignedUrlData.s3Url
+					sourceUri: preSignedUrlData.publicDownloadUrl
 				}
 			];
 		}
@@ -327,7 +327,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 				appIdentifier: settings.projectSettings.projectId,
 				frameworkVersion: cliVersion,
 				runtimeVersion: runtimeVersion,
-				sessionKey: settings.buildCredentials.sessionKey,
+				sessionKey: settings.buildCredentials.sessionKey, // TODO: remove this parameter after we deploy our new server.
 				templateAppName: sanitizedProjectName,
 				projectName: sanitizedProjectName,
 				framework: "tns",
@@ -361,7 +361,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		try {
 			const logs = await this.getContentOfS3File(logsUrl);
 			// The logs variable will contain the full server log and we need to log only the logs that we don't have.
-			const contentToLog = this.$nsCloudBuildOutputFilter.filter(logs.substr(this.outputCursorPosition));
+			const contentToLog = this.$nsCloudOutputFilter.filter(logs.substr(this.outputCursorPosition));
 			if (contentToLog) {
 				const data: IBuildLog = { buildId, data: contentToLog, pipe: "stdout" };
 				this.emit(constants.CLOUD_BUILD_EVENT_NAMES.BUILD_OUTPUT, data);

--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -1,13 +1,9 @@
 import * as path from "path";
 import * as semver from "semver";
 import * as uuid from "uuid";
-import * as forge from "node-forge";
-import * as minimatch from "minimatch";
 import { escape } from "querystring";
-import { EOL } from "os";
 import * as constants from "../constants";
 import { CloudService } from "./cloud-service";
-const plist = require("simple-plist");
 
 export class CloudBuildService extends CloudService implements ICloudBuildService {
 	protected get failedError() {
@@ -21,6 +17,8 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 	constructor($fs: IFileSystem,
 		$httpClient: Server.IHttpClient,
 		$logger: ILogger,
+		private $nsCloudBuildHelper: ICloudBuildHelper,
+		private $nsCloudBuildPropertiesService: ICloudBuildPropertiesService,
 		private $errors: IErrors,
 		private $mobileHelper: Mobile.IMobileHelper,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
@@ -84,10 +82,10 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 			`configuration: '${buildConfiguration}', buildId: ${buildId}`;
 		this.$logger.info(`Starting ${buildInformationString}.`);
 
-		await this.validateBuildProperties(platform, buildConfiguration, projectSettings.projectId, androidBuildData, iOSBuildData);
+		await this.$nsCloudBuildPropertiesService.validateBuildProperties(platform, buildConfiguration, projectSettings.projectId, androidBuildData, iOSBuildData);
 		await this.prepareProject(buildId, projectSettings, platform, buildConfiguration, iOSBuildData);
 		let buildFiles: IServerItemBase[] = [];
-		if (this.$mobileHelper.isAndroidPlatform(platform) && this.isReleaseConfiguration(buildConfiguration)) {
+		if (this.$mobileHelper.isAndroidPlatform(platform) && this.$nsCloudBuildHelper.isReleaseConfiguration(buildConfiguration)) {
 			buildFiles.push({
 				filename: uuid.v4(),
 				fullPath: androidBuildData.pathToCertificate,
@@ -99,7 +97,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 				fullPath: iOSBuildData.pathToCertificate,
 				disposition: constants.DISPOSITIONS.KEYCHAIN
 			});
-			const provisionData = this.getMobileProvisionData(iOSBuildData.pathToProvision);
+			const provisionData = this.$nsCloudBuildHelper.getMobileProvisionData(iOSBuildData.pathToProvision);
 			buildFiles.push({
 				filename: `${provisionData.UUID}.mobileprovision`,
 				fullPath: iOSBuildData.pathToProvision,
@@ -128,9 +126,9 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 			accountId
 		});
 		if (this.$mobileHelper.isAndroidPlatform(platform)) {
-			buildProps = await this.getAndroidBuildProperties(projectSettings, buildProps, filesToUpload, androidBuildData);
+			buildProps = await this.$nsCloudBuildPropertiesService.getAndroidBuildProperties(projectSettings, buildProps, filesToUpload, androidBuildData);
 		} else if (this.$mobileHelper.isiOSPlatform(platform)) {
-			buildProps = await this.getiOSBuildProperties(projectSettings, buildProps, filesToUpload, iOSBuildData);
+			buildProps = await this.$nsCloudBuildPropertiesService.getiOSBuildProperties(projectSettings, buildProps, filesToUpload, iOSBuildData);
 		}
 
 		this.emitStepChanged(buildId, constants.BUILD_STEP_NAME.BUILD, constants.BUILD_STEP_PROGRESS.START);
@@ -186,6 +184,14 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		return result;
 	}
 
+	public validateBuildProperties(platform: string,
+		buildConfiguration: string,
+		appId: string,
+		androidBuildData?: IAndroidBuildData,
+		iOSBuildData?: IIOSBuildData): Promise<void> {
+		return this.$nsCloudBuildPropertiesService.validateBuildProperties(platform, buildConfiguration, appId, androidBuildData, iOSBuildData);
+	}
+
 	private prepareFilesToUpload(amazonStorageEntries: IAmazonStorageEntry[], buildFiles: IServerItemBase[]): IAmazonStorageEntryData[] {
 		let result: IAmazonStorageEntryData[] = [];
 		_.each(amazonStorageEntries, amazonStorageEntry => {
@@ -197,86 +203,6 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		});
 
 		return result;
-	}
-
-	public async validateBuildProperties(platform: string,
-		buildConfiguration: string,
-		appId: string,
-		androidBuildData?: IAndroidBuildData,
-		iOSBuildData?: IIOSBuildData): Promise<void> {
-		if (this.$mobileHelper.isAndroidPlatform(platform) && this.isReleaseConfiguration(buildConfiguration)) {
-			if (!androidBuildData || !androidBuildData.pathToCertificate) {
-				this.$errors.failWithoutHelp("When building for Release configuration, you must specify valid Certificate and its password.");
-			}
-
-			if (!this.$fs.exists(androidBuildData.pathToCertificate)) {
-				this.$errors.failWithoutHelp(`The specified certificate: ${androidBuildData.pathToCertificate} does not exist. Verify the location is correct.`);
-			}
-
-			if (!androidBuildData.certificatePassword) {
-				this.$errors.failWithoutHelp(`No password specified for certificate ${androidBuildData.pathToCertificate}.`);
-			}
-
-			if (androidBuildData.certificatePassword.length < 6) {
-				this.$errors.failWithoutHelp("The password for Android certificate must be at least 6 characters long.");
-			}
-		} else if (this.$mobileHelper.isiOSPlatform(platform) && iOSBuildData.buildForDevice) {
-			if (!iOSBuildData || !iOSBuildData.pathToCertificate || !iOSBuildData.certificatePassword || !iOSBuildData.pathToProvision) {
-				this.$errors.failWithoutHelp("When building for iOS you must specify valid Mobile Provision, Certificate and its password.");
-			}
-
-			if (!this.$fs.exists(iOSBuildData.pathToCertificate)) {
-				this.$errors.failWithoutHelp(`The specified certificate: ${iOSBuildData.pathToCertificate} does not exist. Verify the location is correct.`);
-			}
-
-			if (!this.$fs.exists(iOSBuildData.pathToProvision)) {
-				this.$errors.failWithoutHelp(`The specified provision: ${iOSBuildData.pathToProvision} does not exist. Verify the location is correct.`);
-			}
-
-			const certInfo = this.getCertificateInfo(iOSBuildData.pathToCertificate, iOSBuildData.certificatePassword);
-			const certBase64 = this.getCertificateBase64(certInfo.pemCert);
-			const provisionData = this.getMobileProvisionData(iOSBuildData.pathToProvision);
-			const provisionCertificatesBase64 = _.map(provisionData.DeveloperCertificates, c => c.toString('base64'));
-			const now = Date.now();
-
-			let provisionAppId = provisionData.Entitlements['application-identifier'];
-			_.each(provisionData.ApplicationIdentifierPrefix, prefix => {
-				provisionAppId = provisionAppId.replace(`${prefix}.`, "");
-			});
-
-			let errors: string[] = [];
-
-			if (provisionAppId !== "*") {
-				let provisionIdentifierPattern = new RegExp(this.getRegexPattern(provisionAppId));
-				if (!provisionIdentifierPattern.test(appId)) {
-					errors.push(`The specified provision's (${iOSBuildData.pathToProvision}) application identifier (${provisionAppId}) doesn't match your project's application identifier (${appId}).`);
-				}
-			}
-
-			if (certInfo.organization !== constants.APPLE_INC) {
-				errors.push(`The specified certificate: ${iOSBuildData.pathToCertificate} is issued by an untrusted organization. Please provide a certificate issued by ${constants.APPLE_INC}`);
-			}
-
-			if (now > provisionData.ExpirationDate.getTime()) {
-				errors.push(`The specified provision: ${iOSBuildData.pathToProvision} has expired.`);
-			}
-
-			if (now < certInfo.validity.notBefore.getTime() || now > certInfo.validity.notAfter.getTime()) {
-				errors.push(`The specified certificate: ${iOSBuildData.pathToCertificate} has expired.`);
-			}
-
-			if (!_.includes(provisionCertificatesBase64, certBase64)) {
-				errors.push(`The specified provision: ${iOSBuildData.pathToProvision} does not include the specified certificate: ${iOSBuildData.pathToCertificate}. Please specify a different provision or certificate.`);
-			}
-
-			if (iOSBuildData.deviceIdentifier && !_.includes(provisionData.ProvisionedDevices, iOSBuildData.deviceIdentifier)) {
-				errors.push(`The specified provision: ${iOSBuildData.pathToProvision} does not include the specified device: ${iOSBuildData.deviceIdentifier}.`);
-			}
-
-			if (errors.length) {
-				this.$errors.failWithoutHelp(errors.join(EOL));
-			}
-		}
 	}
 
 	private async prepareProject(buildId: string,
@@ -295,8 +221,8 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		let provision: string;
 
 		if (iOSBuildData && iOSBuildData.pathToProvision) {
-			mobileProvisionData = this.getMobileProvisionData(iOSBuildData.pathToProvision);
-			mobileProvisionData.Type = this.getProvisionType(mobileProvisionData);
+			mobileProvisionData = this.$nsCloudBuildHelper.getMobileProvisionData(iOSBuildData.pathToProvision);
+			mobileProvisionData.Type = this.$nsCloudBuildHelper.getProvisionType(mobileProvisionData);
 			provision = mobileProvisionData.UUID;
 		}
 
@@ -361,7 +287,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		} catch (err) {
 			this.$logger.warn("Unable to use git, reason is:");
 			this.$logger.warn(err.message);
-			const filePath = await this.zipProject(settings.projectSettings.projectDir);
+			const filePath = await this.$nsCloudBuildHelper.zipProject(settings.projectSettings.projectDir);
 			const preSignedUrlData = await this.$nsCloudServerBuildService.getPresignedUploadUrlObject(uuid.v4());
 			const disposition = constants.DISPOSITIONS.PACKAGE_ZIP;
 			settings.filesToUpload.push(_.merge({ filePath, disposition }, preSignedUrlData));
@@ -416,95 +342,6 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		};
 	}
 
-	private getCertificateBase64(cert: string) {
-		return cert.replace(/\s/g, "").substr(constants.CRYPTO.CERTIFICATE_HEADER.length).slice(0, -constants.CRYPTO.CERTIFICATE_FOOTER.length);
-	}
-
-	private async getAndroidBuildProperties(projectSettings: INSCloudProjectSettings,
-		buildProps: any,
-		amazonStorageEntriesData: IAmazonStorageEntryData[],
-		androidBuildData?: IAndroidBuildData): Promise<any> {
-
-		const buildConfiguration = buildProps.properties.buildConfiguration;
-
-		if (this.isReleaseConfiguration(buildConfiguration)) {
-			const certificateData = _.find(amazonStorageEntriesData, amazonStorageEntryData => amazonStorageEntryData.filePath === androidBuildData.pathToCertificate);
-			buildProps.properties.keyStoreName = certificateData.fileName;
-			buildProps.properties.keyStoreAlias = this.getCertificateInfo(androidBuildData.pathToCertificate, androidBuildData.certificatePassword).friendlyName;
-			buildProps.properties.keyStorePassword = androidBuildData.certificatePassword;
-			buildProps.properties.keyStoreAliasPassword = androidBuildData.certificatePassword;
-
-			buildProps.buildFiles.push({
-				disposition: certificateData.disposition,
-				sourceUri: certificateData.s3Url
-			});
-		}
-
-		return buildProps;
-	}
-
-	private async getiOSBuildProperties(projectSettings: INSCloudProjectSettings,
-		buildProps: any,
-		amazonStorageEntriesData: IAmazonStorageEntryData[],
-		iOSBuildData: IIOSBuildData): Promise<any> {
-
-		if (iOSBuildData.buildForDevice) {
-			const provisionData = this.getMobileProvisionData(iOSBuildData.pathToProvision);
-			const certificateData = _.find(amazonStorageEntriesData, amazonStorageEntryData => amazonStorageEntryData.filePath === iOSBuildData.pathToCertificate);
-			const provisonData = _.find(amazonStorageEntriesData, amazonStorageEntryData => amazonStorageEntryData.filePath === iOSBuildData.pathToProvision);
-
-			buildProps.buildFiles.push(
-				{
-					sourceUri: certificateData.s3Url,
-					disposition: certificateData.disposition
-				},
-				{
-					sourceUri: provisonData.s3Url,
-					disposition: provisonData.disposition
-				}
-			);
-
-			buildProps.properties.certificatePassword = iOSBuildData.certificatePassword;
-			buildProps.properties.codeSigningIdentity = this.getCertificateInfo(iOSBuildData.pathToCertificate, iOSBuildData.certificatePassword).commonName;
-
-			const cloudProvisionsData: any[] = [{
-				suffixId: "",
-				templateName: "PROVISION_",
-				identifier: provisionData.UUID,
-				isDefault: true,
-				fileName: provisonData.fileName,
-				appGroups: [],
-				provisionType: this.getProvisionType(provisionData),
-				name: provisionData.Name
-			}];
-			buildProps.properties.mobileProvisionIdentifiers = JSON.stringify(cloudProvisionsData);
-			buildProps.properties.defaultMobileProvisionIdentifier = provisionData.UUID;
-		} else {
-			buildProps.properties.simulator = true;
-		}
-
-		return buildProps;
-	}
-
-	private getProvisionType(provisionData: IMobileProvisionData): string {
-		let result = "";
-		if (provisionData.Entitlements['get-task-allow']) {
-			result = constants.PROVISION_TYPES.DEVELOPMENT;
-		} else {
-			result = constants.PROVISION_TYPES.ADHOC;
-		}
-
-		if (!provisionData.ProvisionedDevices || !provisionData.ProvisionedDevices.length) {
-			if (provisionData.ProvisionsAllDevices) {
-				result = constants.PROVISION_TYPES.ENTERPRISE;
-			} else {
-				result = constants.PROVISION_TYPES.APP_STORE;
-			}
-		}
-
-		return result;
-	}
-
 	private getBuildResultUrl(buildResult: IBuildServerResult): string {
 		// We expect only one buildResult - .ipa, .apk ...
 		return this.getServerResults(buildResult)[0].fullPath;
@@ -545,73 +382,10 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		return targetFileNames[0];
 	}
 
-	private async zipProject(projectDir: string): Promise<string> {
-		let tempDir = path.join(projectDir, constants.CLOUD_TEMP_DIR_NAME);
-		this.$fs.ensureDirectoryExists(tempDir);
-
-		let projectZipFile = path.join(tempDir, "Build.zip");
-		this.$fs.deleteFile(projectZipFile);
-
-		let files = this.getProjectFiles(projectDir, ["node_modules", "platforms", constants.CLOUD_TEMP_DIR_NAME, "**/.*"]);
-
-		await this.$fs.zipFiles(projectZipFile, files, p => this.getProjectRelativePath(p, projectDir));
-
-		return projectZipFile;
-	}
-
-	private getProjectFiles(projectFilesPath: string, excludedProjectDirsAndFiles?: string[], filter?: (filePath: string, stat: IFsStats) => boolean, opts?: any): string[] {
-		const projectFiles = this.$fs.enumerateFilesInDirectorySync(projectFilesPath, (filePath, stat) => {
-			const isFileExcluded = this.isFileExcluded(path.relative(projectFilesPath, filePath), excludedProjectDirsAndFiles);
-			const isFileFiltered = filter ? filter(filePath, stat) : false;
-			return !isFileExcluded && !isFileFiltered;
-		}, opts);
-
-		this.$logger.trace("getProjectFiles for cloud build: ", projectFiles);
-
-		return projectFiles;
-	}
-
-	private isFileExcluded(filePath: string, excludedProjectDirsAndFiles?: string[]): boolean {
-		return !!_.find(excludedProjectDirsAndFiles, (pattern) => minimatch(filePath, pattern, { nocase: true }));
-	}
-
-	private getProjectRelativePath(fullPath: string, projectDir: string): string {
-		projectDir = path.join(projectDir, path.sep);
-		if (!_.startsWith(fullPath, projectDir)) {
-			throw new Error("File is not part of the project.");
-		}
-
-		return fullPath.substring(projectDir.length);
-	}
-
-	private getCertificateInfo(certificatePath: string, certificatePassword: string): ICertificateInfo {
-		const certificateAbsolutePath = path.resolve(certificatePath);
-		const certificateContents: any = this.$fs.readFile(certificateAbsolutePath, { encoding: 'binary' });
-		const pkcs12Asn1 = forge.asn1.fromDer(certificateContents);
-		const pkcs12 = forge.pkcs12.pkcs12FromAsn1(pkcs12Asn1, false, certificatePassword);
-
-		for (let safeContens of pkcs12.safeContents) {
-			for (let safeBag of safeContens.safeBags) {
-				if (safeBag.attributes.localKeyId && safeBag.type === forge.pki.oids['certBag']) {
-					let issuer = safeBag.cert.issuer.getField(constants.CRYPTO.ORGANIZATION_FIELD_NAME);
-					return {
-						pemCert: forge.pki.certificateToPem(safeBag.cert),
-						organization: issuer && issuer.value,
-						validity: safeBag.cert.validity,
-						commonName: safeBag.cert.subject.getField(constants.CRYPTO.COMMON_NAME_FIELD_NAME).value,
-						friendlyName: _.head<string>(safeBag.attributes.friendlyName)
-					};
-				}
-			}
-		}
-
-		this.$errors.failWithoutHelp(`Could not read ${certificatePath}. Please make sure there is a certificate inside.`);
-	}
-
 	private async getImageData(buildResultUrl: string, options: IItmsPlistOptions): Promise<string> {
 		if (options.pathToProvision) {
-			const provisionData = this.getMobileProvisionData(options.pathToProvision);
-			const provisionType = this.getProvisionType(provisionData);
+			const provisionData = this.$nsCloudBuildHelper.getMobileProvisionData(options.pathToProvision);
+			const provisionType = this.$nsCloudBuildHelper.getProvisionType(provisionData);
 			if (provisionType !== constants.PROVISION_TYPES.ADHOC) {
 				return null;
 			}
@@ -622,31 +396,6 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		}
 
 		return this.$qr.generateDataUri(buildResultUrl);
-	}
-
-	private getMobileProvisionData(provisionPath: string): IMobileProvisionData {
-		const provisionText = this.$fs.readText(path.resolve(provisionPath));
-		const provisionPlistText = provisionText.substring(provisionText.indexOf(constants.CRYPTO.PLIST_HEADER), provisionText.indexOf(constants.CRYPTO.PLIST_FOOTER) + constants.CRYPTO.PLIST_FOOTER.length);
-		return plist.parse(provisionPlistText);
-	}
-
-	private isReleaseConfiguration(buildConfiguration: string): boolean {
-		return buildConfiguration.toLowerCase() === constants.CLOUD_BUILD_CONFIGURATIONS.RELEASE.toLowerCase();
-	}
-
-	private getRegexPattern(appIdentifier: string): string {
-		let starPlaceholder = "<!StarPlaceholder!>";
-		let escapedIdentifier = this.escape(this.stringReplaceAll(appIdentifier, "*", starPlaceholder));
-		let replacedIdentifier = this.stringReplaceAll(escapedIdentifier, starPlaceholder, ".*");
-		return "^" + replacedIdentifier + "$";
-	}
-
-	private escape(s: string): string {
-		return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-	}
-
-	private stringReplaceAll(inputString: string, find: any, replace: string): string {
-		return inputString.split(find).join(replace);
 	}
 
 	private emitStepChanged(buildId: string, step: string, progress: number): void {

--- a/lib/services/cloud-project-service.ts
+++ b/lib/services/cloud-project-service.ts
@@ -15,6 +15,7 @@ export class CloudProjectService extends CloudService implements ICloudProjectSe
 	constructor($fs: IFileSystem,
 		$httpClient: Server.IHttpClient,
 		$logger: ILogger,
+		private $nsCloudOutputFilter: ICloudOutputFilter,
 		private $nsCloudServerProjectService: IServerProjectService,
 		private $projectHelper: IProjectHelper) {
 		super($fs, $httpClient, $logger);
@@ -71,12 +72,9 @@ export class CloudProjectService extends CloudService implements ICloudProjectSe
 			try {
 				await this.waitForServerOperationToFinish(taskId, task);
 				const taskResult = await this.getObjectFromS3File<IServerResult>(task.resultUrl);
-				if (this.hasContent(taskResult.stdout)) {
-					this.$logger.info(taskResult.stdout);
-				}
-
-				if (this.hasContent(taskResult.stderr)) {
-					this.$logger.error(taskResult.stderr);
+				const output = this.$nsCloudOutputFilter.filter(await this.getContentOfS3File(task.outputUrl));
+				if (this.hasContent(output)) {
+					this.$logger.info(output);
 				}
 
 				tasksResults[taskId] = taskResult;

--- a/lib/services/cloud-service.ts
+++ b/lib/services/cloud-service.ts
@@ -8,10 +8,6 @@ export abstract class CloudService extends EventEmitter {
 	private static OPERATION_COMPLETE_STATUS = "Success";
 	private static OPERATION_FAILED_STATUS = "Failed";
 	private static OPERATION_IN_PROGRESS_STATUS = "Building";
-	private static GET_TRANSFORMED_RESULT_MAX_WAIT = 3 * 1000;
-	private static GET_TRANSFORMED_RESULT_REQUEST_INTERVAL = 500;
-	private static GET_TRANSFORMED_RESULT_RETRIES_COUNT =
-		Math.floor(CloudService.GET_TRANSFORMED_RESULT_MAX_WAIT / CloudService.GET_TRANSFORMED_RESULT_REQUEST_INTERVAL);
 
 	protected outputCursorPosition: number;
 	protected abstract failedToStartError: string;
@@ -97,27 +93,5 @@ export abstract class CloudService extends EventEmitter {
 		}
 
 		return targetFileNames;
-	}
-
-	protected async getTransformedServerResult(transformedBuildResultUrl: string): Promise<IBuildServerResult> {
-		return new Promise<IBuildServerResult>((resolve, reject) => {
-			let retriesCount = 1;
-			const intervalId = setInterval(async () => {
-				if (retriesCount > CloudService.GET_TRANSFORMED_RESULT_RETRIES_COUNT) {
-					clearInterval(intervalId);
-					return resolve(null);
-				}
-
-				retriesCount++;
-				try {
-					const result = await this.getObjectFromS3File<IBuildServerResult>(transformedBuildResultUrl);
-					clearInterval(intervalId);
-					return resolve(result);
-				} catch (err) {
-					this.$logger.trace("Error while getting results-transformed.json file:");
-					this.$logger.trace(err);
-				}
-			}, CloudService.GET_TRANSFORMED_RESULT_REQUEST_INTERVAL);
-		});
 	}
 }


### PR DESCRIPTION
We need to start using the pre-signed download urls returned from our server for all cloud operations because the server will not accept s3 paths anymore.


The project service will start printing the content of output.log file instead of the stdout and stderr of results.json because our daemon will stop sending those properties for successful cloud operations.