### PR TITLE
Remove validatePlatform for run command

### DIFF
--- a/lib/commands/cloud-run.ts
+++ b/lib/commands/cloud-run.ts
@@ -31,8 +31,6 @@ export class CloudRunCommand implements ICommand {
 			this.$errors.fail("This input is not valid for the cloud run command");
 		}
 
-		this.$liveSyncCommandHelper.validatePlatform(this.platform);
-
 		return true;
 	}
 }


### PR DESCRIPTION
In case when `tns cloud run` command is executed and the local environment is not correctly configured, {N} CLI shows a prompt with 4 options (configure for local builds, configure for cloud builds, configure for both - local and cloud builds, setup manually) to configure automatically the environment. This prompt should not be shown in case when cloud commands are executed.
We discussed the situation and agreed the whole `validatePlatform` method is not needed for cloud run command.

This PR fixes the behaviour with missing await.