### PR TITLE
Print the publish error

### DIFF
--- a/lib/services/cloud-publish-service.ts
+++ b/lib/services/cloud-publish-service.ts
@@ -79,8 +79,7 @@ export class CloudPublishService extends CloudService implements ICloudPublishSe
 
 	private getiOSError(publishResult: IBuildServerResult, publishRequestData: IPublishRequestData) {
 		const itmsMessage = this.getFormattedError(publishResult.stdout, CloudPublishService.ITMS_ERROR_REGEX);
-		const generalMessage = this.getFormattedError(publishResult.stderr, CloudPublishService.GENERAL_ERROR_REGEX);
-		const err = new Error(`${publishResult.errors}${EOL}${itmsMessage}${EOL}${generalMessage}`);
+		const err = new Error(`${publishResult.errors}${EOL}${itmsMessage}${EOL}${publishResult.stderr}`);
 		return err;
 	}
 
@@ -101,7 +100,7 @@ export class CloudPublishService extends CloudService implements ICloudPublishSe
 		try {
 			await this.waitForServerOperationToFinish(buildId, response);
 		} catch (ex) {
-			this.$logger.trace("Codesign generation failed with err: ", ex);
+			this.$logger.trace("Publish failed with err: ", ex);
 		}
 
 		const publishResult = await this.getObjectFromS3File<IBuildServerResult>(response.resultUrl);


### PR DESCRIPTION
When the cloud publish fails with non ITMS error (e.g. not accepted
license agreement, wrong password), we show only part of the error which
can be `The request could not be completed because:` and the real reason
is hidden. We decided to show the whole stderr to solve this problem.
In case of ITMS error, it will be displayed and the github issues
information displayed by fastlane will be hidden because it is displayed
on the stdout which is filtered.