### PR TITLE
feat: Remove check for Kinvey EULA when sending requests

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -24,10 +24,11 @@ $injector.requirePublicClass("nsCloudProjectService", path.join(__dirname, "serv
 $injector.requirePublicClass("nsCloudUserService", path.join(__dirname, "services", "user-service"));
 $injector.requirePublicClass("nsCloudAccountsService", path.join(__dirname, "services", "accounts-service"));
 $injector.requirePublicClass("nsCloudEulaService", path.join(__dirname, "services", "eula-service"));
-$injector.requirePublicClass("nsCloudKinveyEulaService", path.join(__dirname, "services", "kinvey-eula-service"));
 $injector.requirePublicClass("nsCloudKinveyService", path.join(__dirname, "services", "kinvey-service"));
 $injector.requirePublicClass("nsCloudPolicyService", path.join(__dirname, "services", "policy-service"));
 $injector.requirePublicClass("nsCloudServicesPolicyService", path.join(__dirname, "services", "cloud-services-policy-service"));
+// TODO: Remove in 2.0.0 - currently this service is not used, but it has been publicly exposed, so we cannot remove it without bumping the major version.
+$injector.requirePublicClass("nsCloudKinveyEulaService", path.join(__dirname, "services", "kinvey-eula-service"));
 
 // Services.
 $injector.require("nsCloudServerAuthService", path.join(__dirname, "services", "server", "server-auth-service"));

--- a/lib/services/kinvey-eula-service.ts
+++ b/lib/services/kinvey-eula-service.ts
@@ -1,6 +1,7 @@
 import { EulaConstants } from "../constants";
 import { EulaServiceBase } from "./eula-service-base";
 
+// TODO: Remove in 2.0.0 - currently this service is not used, but it has been publicly exposed, so we cannot remove it without bumping the major version.
 export class KinveyEulaService extends EulaServiceBase implements IEulaService {
 	constructor($fs: IFileSystem,
 		$httpClient: Server.IHttpClient,

--- a/lib/services/server/mbaas/kinvey-request-service.ts
+++ b/lib/services/server/mbaas/kinvey-request-service.ts
@@ -7,8 +7,7 @@ export class KinveyRequestService extends ServerServiceBase implements IKinveyRe
 	}
 
 	constructor($injector: IInjector,
-		$nsCloudMBaasRequestService: IServerRequestService,
-		private $nsCloudKinveyEulaService: IEulaService) {
+		$nsCloudMBaasRequestService: IServerRequestService) {
 		super($nsCloudMBaasRequestService, $injector);
 	}
 
@@ -65,12 +64,7 @@ export class KinveyRequestService extends ServerServiceBase implements IKinveyRe
 	}
 
 	protected async ensureEulaIsAccepted(): Promise<void> {
-		const eulaData = await this.$nsCloudKinveyEulaService.getEulaData();
-		if (eulaData.shouldAcceptEula) {
-			this.$errors.failWithoutHelp("Kinvey EULA not accepted, cannot use Kinvey services.");
-		}
-
-		return super.ensureEulaIsAccepted();
+		// Intentionally left blank - no need to accept Kinvey EULA.
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {


### PR DESCRIPTION
In case we send requests to Kinvey, we check if Kinvey EULA has been accepted. This is not required anymore, so remove the check from the `kinvey-request-service`.
As the nsCloudKinveyEulaService has been publicly exposed, we cannot remove it without bumping the major version. So keep it in the code until we prepare for 2.0.0 release