### PR TITLE
Default errors string

### DIFF
--- a/lib/services/cloud-publish-service.ts
+++ b/lib/services/cloud-publish-service.ts
@@ -106,6 +106,8 @@ export class CloudPublishService extends CloudService implements ICloudPublishSe
 		const publishResult = await this.getObjectFromS3File<IBuildServerResult>(response.resultUrl);
 		this.$logger.trace("Publish result:", publishResult);
 
+		publishResult.errors = publishResult.errors || "";
+
 		if (publishResult.code || publishResult.errors) {
 			const err = getError(publishResult, publishRequestData);
 			err.stderr = publishResult.stderr;


### PR DESCRIPTION
In case server does not return an `errors` property we'll get an undefined later on when displaying the error. Mitigate that.

Ping @rosen-vladimirov 