### PR TITLE
Integrate the latest changes in {N} CLI

### DIFF
--- a/lib/commands/cloud-codesign.ts
+++ b/lib/commands/cloud-codesign.ts
@@ -56,7 +56,7 @@ export class CloudCodesignCommand implements ICommand {
 			this.$errors.fail(ERROR_MESSAGES.COMMAND_REQUIRES_APPLE_USERNAME_PASS);
 		}
 
-		await this.$devicesService.detectCurrentlyAttachedDevices({ shouldReturnImmediateResult: false, platform: this.platform });
+		await this.$devicesService.initialize({ shouldReturnImmediateResult: false, platform: this.platform, skipEmulatorStart: true });
 		this.devices = this.$devicesService.getDeviceInstances()
 			.filter(d => !d.isEmulator && d.deviceInfo.platform.toLowerCase() === this.platform.toLowerCase())
 			.map(d => d.deviceInfo);

--- a/lib/services/application-service.ts
+++ b/lib/services/application-service.ts
@@ -1,15 +1,33 @@
+import * as semver from "semver";
+
 export class ApplicationService implements IApplicationService {
 	constructor(private $platformService: IPlatformService,
 		private $projectDataService: IProjectDataService,
 		private $devicesService: Mobile.IDevicesService,
-		private $projectChangesService: IProjectChangesService) {
+		private $projectChangesService: IProjectChangesService,
+		private $staticConfig: IStaticConfig,
+		private $logger: ILogger) {
 	}
 
 	public async shouldBuild(config: IApplicationBuildConfig): Promise<boolean> {
 		const projectData = this.$projectDataService.getProjectData(config.projectDir);
 		config.release = config.release === undefined ? false : config.release;
 		config.bundle = config.bundle === undefined ? false : config.bundle;
-		await this.$projectChangesService.checkForChanges(config.platform, projectData, config);
+
+		const cliVersion = this.$staticConfig.version;
+		const shouldUseOldCheckForChanges = semver.valid(cliVersion) && semver.lt(cliVersion, semver.prerelease(cliVersion) ? "4.2.0-2018-07-17-11996" : "4.2.0");
+		if (shouldUseOldCheckForChanges) {
+			// Backwards compatibility as checkForChanges method has different args in old versions
+			this.$logger.trace(`Using old checkForChanges as CLI version is ${cliVersion}.`);
+			await (<any>this.$projectChangesService).checkForChanges(config.platform, projectData, config);
+		} else {
+			await this.$projectChangesService.checkForChanges({
+				platform: config.platform,
+				projectData,
+				projectChangesOptions: config
+			});
+		}
+
 		return this.$platformService.shouldBuild(config.platform, projectData, config, config.outputPath);
 	}
 


### PR DESCRIPTION
In older CLI versions the `checkForChanges` method has different arguments. Fix the backwards compatibility by checking CLI's version and call the method with correct args.

Fix the `cloud codesign` command.