### PR TITLE
fix: transpilation is failing due to missing implementation

### DIFF
--- a/lib/mobile/device/cloud-emulator-device-file-system.ts
+++ b/lib/mobile/device/cloud-emulator-device-file-system.ts
@@ -12,4 +12,6 @@ export class CloudEmulatorDeviceFileSystem implements Mobile.IDeviceFileSystem {
 	public async transferFile(localPath: string, devicePath: string): Promise<void> { /* currently empty */ }
 
 	public async createFileOnDevice(deviceFilePath: string, fileContent: string): Promise<void> { /* currently empty */ }
+
+	public async deleteFile(deviceFilePath: string, appIdentifier: string): Promise<void> { /* currently empty */ }
 }


### PR DESCRIPTION
The underlying interface for Device File System has changed, so implement the new method that is required.