### PR TITLE
feat: pass --hmr to cloud build

### DIFF
--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -115,8 +115,16 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		const filesToUpload = this.prepareFilesToUpload(buildCredentials.urls, buildFiles);
 		const additionalCliFlags: string[] = [];
 		if (projectSettings.bundle) {
+			additionalCliFlags.push("--bundle");
+		}
+
+		if (projectSettings.useHotModuleReload) {
+			additionalCliFlags.push("--hmr");
+		}
+
+		if (projectSettings.env) {
 			const envOptions = _.keys(projectSettings.env).map(option => `--env.${option}`);
-			additionalCliFlags.push("--bundle", ...envOptions);
+			additionalCliFlags.push(...envOptions);
 		}
 
 		let buildProps = await this.prepareBuildRequest({


### PR DESCRIPTION
Whenever we want to use Hot Module Reload, we have to pass `--hmr` option to the build in the cloud.
Also move the passing of `--env` flags to a separate `if` as `--env` can now be passed with `--hmr` and `--bundle` flags.