### PR TITLE
fix: hmr is not working in some cases

### DIFF
--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -191,7 +191,10 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 			}
 		};
 
-		if ((<any>this.$filesHashService).saveHashesForProject) {
+		// In case HMR is passed, do not save the hashes as the files generated in the cloud may differ from the local ones.
+		// We need to get the hashes from the cloud build, so until we have it, it is safer to execute fullSync after build.
+		// This way we'll be sure HMR is working with cloud builds as it will rely on the local files.
+		if ((<any>this.$filesHashService).saveHashesForProject && !projectSettings.useHotModuleReload) {
 			const platformData = this.$platformsData.getPlatformData(platform, this.$projectDataService.getProjectData(projectSettings.projectDir));
 			await (<any>this.$filesHashService).saveHashesForProject(platformData, path.dirname(localBuildResult));
 		}

--- a/lib/services/git-service.ts
+++ b/lib/services/git-service.ts
@@ -168,7 +168,7 @@ export class GitService implements IGitService {
 			const result = await this.executeCommand(projectSettings, ["config", "core.autocrlf"]);
 			return result && result.stdout && result.stdout.toString().trim().toLowerCase() === "false";
 		} catch (err) {
-			this.$logger.trace("Error while checking if core.autcrlf is false: ", err);
+			this.$logger.trace("Error while checking if core.autocrlf is false: ", err);
 			return false;
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {


### PR DESCRIPTION
### fix: hmr is not working when git is used to upload files
Using cloud build with Hot Module Replacement is not working when git is used as it modifies the line endings. Most of the templates are published from Windows machine, so the line endings in them are `\r\n`.
The local prepare of the project produces bundle.js with `hotCurrentHash = <value 1>`. Once we use git to push the files in the cloud, the line endings are `\n`. The `bundle.js` produced in the cloud contains `hotCurrentHash = <value 2>`.
After the built .apk is downloaded from the cloud and installed on device, CLI does not apply full sync as it thinks the local files are the same as the ones in the cloud.
In order to fix this, set `core.autocrlf` to false in the local codecommit repo. This way the line endings will be the same and the `hotCurrentHash` should be the same in the cloud and locally. In order to force creation of new repo, add a versioning to the dir name of the local repo.
This allows us to force creation of new repo in this case.

### fix: do not generate nshashes file when --hmr is used
When cloud build is used with hmr, the files generated in the cloud (bundle.js especially) may differ from the local ones.
Currently we build the app in the cloud and generate hashes locally based on the local files, instead of getting them from the cloud. This works in normal case, but not for HMR.
Until we get the hashes from the cloud, skip generation of nshashes in case hmr is passed.