### PR TITLE
Send kinvey instanceId header to the server.

### DIFF
--- a/lib/account-utils.ts
+++ b/lib/account-utils.ts
@@ -1,0 +1,24 @@
+import { NAMESPACE_LOWER_CASE } from "./constants";
+
+import { isKinveyNamespace } from "./helpers";
+
+export class AccountUtils implements IAccountUtils {
+	private get $nsCloudKinveyService(): IKinveyService {
+		return this.$injector.resolve<IKinveyService>("nsCloudKinveyService");
+	}
+
+	constructor(private $nsCloudServerConfigManager: IServerConfigManager,
+		private $injector: IInjector, ) { }
+
+	public isKinveyUser(): boolean {
+		const serverConfig = this.$nsCloudServerConfigManager.getCurrentConfigData();
+		const namespace: string = serverConfig[NAMESPACE_LOWER_CASE];
+		return isKinveyNamespace(namespace);
+	}
+
+	public async getKinveyAccountsMap(): Promise<IAccount[]> {
+		return (await this.$nsCloudKinveyService.getApps()).map(a => ({ id: a.id, name: a.name, type: a.plan && a.plan.level }));
+	}
+}
+
+$injector.register("nsAccountUtils", AccountUtils);

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -9,6 +9,7 @@ $injector.require("nsCloudOutputFilter", path.join(__dirname, "cloud-output-filt
 $injector.require("nsCloudDeviceEmulator", path.join(__dirname, "cloud-device-emulator"));
 $injector.require("nsCloudOptionsProvider", path.join(__dirname, "cloud-options-provider"));
 $injector.require("nsCloudBuildHelper", path.join(__dirname, "cloud-build-helper"));
+$injector.require("nsAccountUtils", path.join(__dirname, "account-utils"));
 $injector.require("nsCloudBuildCommandHelper", path.join(__dirname, "commands", "build-command-helper"));
 $injector.require("nsCloudEulaCommandHelper", path.join(__dirname, "commands", "eula-command-helper"));
 $injector.require("nsCloudAndroidBundleValidatorHelper", path.join(__dirname, "cloud-android-bundle-validator-helper"));

--- a/lib/cloud-options-provider.ts
+++ b/lib/cloud-options-provider.ts
@@ -8,6 +8,7 @@ export class CloudOptionsProvider implements ICloudOptionsProvider {
 			local: { type: OptionType.Boolean, hasSensitiveValue: false },
 			serverProto: { type: OptionType.String , hasSensitiveValue: true},
 			namespace: { type: OptionType.String, hasSensitiveValue: true },
+			instanceId: {type: OptionType.String, hasSensitiveValue: false },
 			sharedCloud: { type: OptionType.Boolean, hasSensitiveValue: false },
 			workflow: { type: OptionType.Object, hasSensitiveValue: true },
 			vmTemplateName: { type: OptionType.String, hasSensitiveValue: false },

--- a/lib/commands/dev-login.ts
+++ b/lib/commands/dev-login.ts
@@ -4,8 +4,14 @@ export class DevLoginCommand implements ICommand {
 		this.$stringParameterBuilder.createMandatoryParameter("Missing user name or password.")
 	];
 
+	public get dashedOptions() {
+		return this.$nsCloudOptionsProvider.dashedOptions;
+	}
+
 	constructor(private $errors: IErrors,
 		private $logger: ILogger,
+		private $options: ICloudOptions,
+		private $nsCloudOptionsProvider: ICloudOptionsProvider,
 		private $nsCloudAuthenticationService: IAuthenticationService,
 		private $nsCloudServicesPolicyService: ICloudServicesPolicyService,
 		private $stringParameterBuilder: IStringParameterBuilder) { }
@@ -16,7 +22,7 @@ export class DevLoginCommand implements ICommand {
 		}
 
 		try {
-			await this.$nsCloudAuthenticationService.devLogin(args[0], args[1]);
+			await this.$nsCloudAuthenticationService.devLogin(args[0], args[1], this.$options.instanceId || "");
 		} catch (err) {
 			this.$errors.failWithoutHelp(err.message);
 		}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -28,6 +28,8 @@ export const ACCOUNTS_SERVICE_NAME = "accounts-service";
 export const PROJECT_SERVICE_NAME = "project-service";
 export const DEFAULT_ANDROID_PUBLISH_TRACK = "beta";
 export const UNLIMITED = "unlimited";
+export const NAMESPACE_LOWER_CASE = "namespace";
+export const KINVEY_LOWER_CASE = "kinvey";
 
 export const CLOUD_BUILD_EVENT_NAMES = {
 	BUILD_OUTPUT: "buildOutput",
@@ -77,7 +79,8 @@ export const HTTP_HEADERS = {
 	CONNECTION: "Connection",
 	CONTENT_TYPE: "Content-Type",
 	LOCATION: "Location",
-	X_NS_NAMESPACE: "X-NS-Namespace"
+	X_NS_NAMESPACE: "X-NS-Namespace",
+	X_NS_INSTANCE_ID: "X-NS-Instance-Id"
 };
 
 export const HTTP_STATUS_CODES = {

--- a/lib/definitions/account-utils.d.ts
+++ b/lib/definitions/account-utils.d.ts
@@ -1,0 +1,4 @@
+interface IAccountUtils {
+	isKinveyUser(): boolean;
+	getKinveyAccountsMap(): Promise<IAccount[]>;
+}

--- a/lib/definitions/authentication-service.d.ts
+++ b/lib/definitions/authentication-service.d.ts
@@ -5,7 +5,7 @@ interface IAuthenticationService {
 	 * @param {string} password The password of the user.
 	 * @returns {Promise<IUser>} Returns the user information after successful login.
 	 */
-	devLogin(username: string, password: string): Promise<IUser>;
+	devLogin(username: string, password: string, instanceId?: string): Promise<IUser>;
 
 	/**
 	 * Opens login page and after successful login saves the user information.
@@ -58,6 +58,7 @@ interface ILoginOptions extends IOpenActionOptions {
 interface IUserData extends ITokenData {
 	refreshToken: string;
 	userInfo: IUser;
+	instanceId?: string;
 }
 
 interface ITokenData {
@@ -88,9 +89,10 @@ interface IKinveyUserData {
 	email: string;
 	firstName: string;
 	lastName: string
+	instanceId: string
+	token: string;
 	lastLoginTime?: Date;
 	name?: string;
-	token: string;
 	twoFactorAuth?: IKinveyTwoFactorAuth
 }
 

--- a/lib/definitions/cloud-options.d.ts
+++ b/lib/definitions/cloud-options.d.ts
@@ -7,6 +7,7 @@ interface ICloudOptions extends IOptions, ISharedCloud {
 	local: boolean;
 	serverProto: string;
 	namespace: string;
+	instanceId: string;
 	track: string;
 	workflow: IWorkflowPropertyOptions;
 	vmTemplateName: string;

--- a/lib/definitions/server/server-auth-service.d.ts
+++ b/lib/definitions/server/server-auth-service.d.ts
@@ -1,5 +1,5 @@
 interface IServerAuthService {
-	devLogin(username: string, password: string): Promise<IUserData>;
+	devLogin(username: string, password: string, instanceId?: string): Promise<IUserData>;
 	getLoginUrl(port: number): string;
 	refreshToken(refreshToken: string): Promise<ITokenData>;
 	getTokenState(token: string): Promise<ITokenState>;

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -1,4 +1,5 @@
 import { parse } from "url";
+import { KINVEY_LOWER_CASE } from "./constants";
 import * as randomstring from "randomstring";
 
 const Table = require("cli-table");
@@ -23,6 +24,10 @@ export function createTable(headers: string[], data: string[][]): any {
 
 export function stringifyWithIndentation(data: any, indentation?: string | number): string {
 	return JSON.stringify(data, null, indentation || "  ");
+}
+
+export function isKinveyNamespace(namespace: string) {
+	return namespace && namespace.toLowerCase() === KINVEY_LOWER_CASE;
 }
 
 export function isUrl(data: string): boolean {

--- a/lib/services/authentication-service.ts
+++ b/lib/services/authentication-service.ts
@@ -112,8 +112,9 @@ export class AuthenticationService implements IAuthenticationService {
 		return userInfo;
 	}
 
-	public async devLogin(username: string, password: string): Promise<IUser> {
-		const userData = await this.$nsCloudServerAuthService.devLogin(username, password);
+	public async devLogin(username: string, password: string, instanceId?: string): Promise<IUser> {
+		const userData = await this.$nsCloudServerAuthService.devLogin(username, password, instanceId);
+		userData.instanceId = instanceId;
 		this.$nsCloudUserService.setUserData(userData);
 
 		return userData.userInfo;

--- a/lib/services/kinvey-user-service.ts
+++ b/lib/services/kinvey-user-service.ts
@@ -18,6 +18,7 @@ export class KinveyUserService extends UserServiceBase implements IUserService {
 		return {
 			accessToken: userData.token,
 			refreshToken: "",
+			instanceId: userData.instanceId,
 			userInfo: {
 				email: userData.email,
 				firstName: userData.firstName,
@@ -31,7 +32,8 @@ export class KinveyUserService extends UserServiceBase implements IUserService {
 			email: userData.userInfo.email,
 			firstName: userData.userInfo.firstName,
 			lastName: userData.userInfo.lastName,
-			token: userData.accessToken
+			token: userData.accessToken,
+			instanceId: userData.instanceId
 		};
 
 		super.setUserData(kinveyUserData);

--- a/lib/services/server/server-services-proxy.ts
+++ b/lib/services/server/server-services-proxy.ts
@@ -25,6 +25,10 @@ export class ServerServicesProxy implements IServerServicesProxy {
 		const namespace = this.getServiceValueOrDefault(options.serviceName, "namespace");
 		if (namespace) {
 			headers[HTTP_HEADERS.X_NS_NAMESPACE] = namespace;
+			if (this.$nsCloudUserService.hasUser()) {
+				const userData = this.$nsCloudUserService.getUserData();
+				headers[HTTP_HEADERS.X_NS_INSTANCE_ID] = userData.instanceId || "";
+			}
 		}
 
 		if (options.accept) {


### PR DESCRIPTION
Allow users with Single-Tenant Cloud Instance to login and perform cloud builds.