### PR TITLE
fix: update @types/promise-retry to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@types/chai-as-promised": "0.0.31",
     "@types/node": "8.10.30",
     "@types/node-forge": "0.6.7",
-    "@types/promise-retry": "1.1.1",
+    "@types/promise-retry": "1.1.3",
     "@types/randomstring": "1.1.6",
     "@types/request": "0.0.45",
     "@types/semver": "5.3.30",


### PR DESCRIPTION
Fix the master build by updating `@types/promise-retry` to latest version. Currently the build fails as `@types/promise-retry`'s 1.1.1 version depends on `@types/retry` package with `*`, which means it always installs the latest version.
The `.d.ts` files in the latest `@types/retry` package are for newer version, which has breaking change in the API, so our transpilation fails. The issue is fixed in `@types/promise-retry` by using specific version of the `@types/retry` package.