### PR TITLE
Add nsCloudConfigManager to the public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ tns.extensibilityService.installExtension("nativescript-cloud@latest")
   * [getAuthServices](#getauthservices-method)
   * [getDefaultAuthService](#getdefaultauthservice-method)
   * [changeDefaultAuthService](#changedefaultauthservice-method)
+* [nsCloudConfigManager](#nscloudconfigmanager)
+  * [reset](#reset-method)
+  * [applyConfig](#applyConfig-method)
+  * [getCurrentConfigData](#getCurrentConfigData-method)
+  * [getServiceDomainName](#getServiceDomainName-method)
+  * [getCloudServicesDomainNames](#getCloudServicesDomainNames-method)
+  * [getServiceValueOrDefault](#getServiceValueOrDefault-method)
+  * [printConfigData](#printConfigData-method)
 
 ### nsCloudBuildService
 The `nsCloudBuildService` allows build of applications in the cloud. You can call the following methods:
@@ -1468,6 +1476,165 @@ tns.nsCloudKinveyService.getAuthServices({ environmentId: "<env-id>" })
 	.catch(err => console.error("Unable to change dafault auth service. Error is: ", err));
 
 ```
+
+### nsCloudConfigManager
+The `nsCloudConfigManager` allows to manage cloud configuration. You can call the following methods:
+
+#### reset method
+`reset` resets the current cloud configuration to the default one - production. </br>
+Definition:
+
+```TypeScript
+/**
+ * Resets config.json to it's default values.
+ * @returns {void}
+ */
+reset(): void;
+```
+Detailed description of each parameter can be found [here](./lib/definitions/cloud-config-manager.d.ts).
+</br>
+
+Usage:
+```JavaScript
+const tns = require("nativescript");
+
+tns.nsCloudConfigManager.reset();
+```
+
+#### applyConfig method
+`applyConfig` applies specific configuration and saves it in config.json. </br>
+Definition:
+
+```TypeScript
+/**
+ * Applies specific configuration and saves it in config.json
+ * @param {string} configName The name of the configuration to be applied.
+ * @param {IConfigOptions} [options] The config options.
+ * @param {IServerConfigBase} [globalServerConfig] The global server configuration which will
+ * be used when changing the configuration. This parameter will override the default global configuration.
+ * @returns {void}
+ */
+applyConfig(configName: string, options?: IConfigOptions, globalServerConfig?: IServerConfigBase): void;
+```
+Detailed description of each parameter can be found [here](./lib/definitions/cloud-config-manager.d.ts).
+</br>
+
+Usage:
+```JavaScript
+const tns = require("nativescript");
+
+tns.nsCloudConfigManager.applyConfig("test");
+```
+
+#### getCurrentConfigData method
+`getCurrentConfigData` returns the current cloud configuration. </br>
+Definition:
+
+```TypeScript
+/**
+ * Returns the current cloud configuration.
+ * @returns {IServerConfig}
+ */
+getCurrentConfigData(): IServerConfig;
+```
+Detailed description of each parameter can be found [here](./lib/definitions/cloud-config-manager.d.ts).
+</br>
+
+Usage:
+```JavaScript
+const tns = require("nativescript");
+
+console.log(tns.nsCloudConfigManager.getCurrentConfigData());
+```
+
+#### getServiceDomainName method
+`getServiceDomainName` returns the domain of the provided cloud service. </br>
+Definition:
+
+```TypeScript
+/**
+ * Returns the domain of the provided cloud service.
+ * @param serviceName The name of the cloud service.
+ * @returns {string}
+ */
+getServiceDomainName(serviceName: string): string;
+```
+Detailed description of each parameter can be found [here](./lib/definitions/cloud-config-manager.d.ts).
+</br>
+
+Usage:
+```JavaScript
+const tns = require("nativescript");
+
+console.log(tns.nsCloudConfigManager.getServiceDomainName("accounts-service"));
+```
+
+#### getCloudServicesDomainNames method
+`getCloudServicesDomainNames` returns the domain names of all cloud services. </br>
+Definition:
+
+```TypeScript
+/**
+ * Returns the domain names of all cloud services.
+ * @returns {string[]} The domain names of all cloud services.
+ */
+getCloudServicesDomainNames(): string[];
+```
+Detailed description of each parameter can be found [here](./lib/definitions/cloud-config-manager.d.ts).
+</br>
+
+Usage:
+```JavaScript
+const tns = require("nativescript");
+
+console.log(tns.nsCloudConfigManager.getCloudServicesDomainNames());
+```
+
+#### getServiceValueOrDefault method
+`getServiceValueOrDefault` returns the value stored in the configuration of the provided service or the default value stored in the global configuration. </br>
+Definition:
+
+```TypeScript
+/**
+ * Returns the value stored in the configuration of the provided service or the default value stored in the
+ * global configuration.
+ * @param serviceName The name of the cloud service.
+ * @param valueName The name of the value.
+ * @returns {string} The value specified in the provided service config or the value specified in the global config.
+ */
+getServiceValueOrDefault(serviceName: string, valueName: string): string;
+```
+Detailed description of each parameter can be found [here](./lib/definitions/cloud-config-manager.d.ts).
+</br>
+
+Usage:
+```JavaScript
+const tns = require("nativescript");
+
+console.log(tns.nsCloudConfigManager.getServiceValueOrDefault("accounts-service", "serverProto"));
+```
+
+#### printConfigData method
+`printConfigData` prints the current cloud configuration on the stdout of the process. </br>
+Definition:
+
+```TypeScript
+/**
+ * Prints the current cloud configuration on the stdout of the process.
+ * @returns {void}
+ */
+printConfigData(): void;
+```
+Detailed description of each parameter can be found [here](./lib/definitions/cloud-config-manager.d.ts).
+</br>
+
+Usage:
+```JavaScript
+const tns = require("nativescript");
+
+tns.nsCloudConfigManager.printConfigData();
+```
+
 
 ## Development
 The project is written in TypeScript. After cloning it, you can set it up by executing the following commands in your terminal:

--- a/lib/account-utils.ts
+++ b/lib/account-utils.ts
@@ -7,11 +7,11 @@ export class AccountUtils implements IAccountUtils {
 		return this.$injector.resolve<IKinveyService>("nsCloudKinveyService");
 	}
 
-	constructor(private $nsCloudServerConfigManager: IServerConfigManager,
+	constructor(private $nsCloudConfigManager: ICloudConfigManager,
 		private $injector: IInjector, ) { }
 
 	public isKinveyUser(): boolean {
-		const serverConfig = this.$nsCloudServerConfigManager.getCurrentConfigData();
+		const serverConfig = this.$nsCloudConfigManager.getCurrentConfigData();
 		const namespace: string = serverConfig[NAMESPACE_LOWER_CASE];
 		return isKinveyNamespace(namespace);
 	}

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -2,7 +2,6 @@ import * as path from "path";
 
 $injector.require("nsCloudHttpServer", path.join(__dirname, "http-server"));
 $injector.require("nsCloudItmsServicesPlistHelper", path.join(__dirname, "itms-services-plist-helper"));
-$injector.require("nsCloudServerConfigManager", path.join(__dirname, "server-config-manager"));
 $injector.require("nsCloudOutputFilter", path.join(__dirname, "cloud-output-filter"));
 $injector.require("nsCloudDeviceEmulator", path.join(__dirname, "cloud-device-emulator"));
 $injector.require("nsCloudOptionsProvider", path.join(__dirname, "cloud-options-provider"));
@@ -32,6 +31,7 @@ $injector.requirePublicClass("nsCloudEulaService", path.join(__dirname, "service
 $injector.requirePublicClass("nsCloudKinveyService", path.join(__dirname, "services", "kinvey-service"));
 $injector.requirePublicClass("nsCloudPolicyService", path.join(__dirname, "services", "policy-service"));
 $injector.requirePublicClass("nsCloudServicesPolicyService", path.join(__dirname, "services", "cloud-services-policy-service"));
+$injector.requirePublicClass("nsCloudConfigManager", path.join(__dirname, "cloud-config-manager"));
 // TODO: Remove in 2.0.0 - currently this service is not used, but it has been publicly exposed, so we cannot remove it without bumping the major version.
 $injector.requirePublicClass("nsCloudKinveyEulaService", path.join(__dirname, "services", "kinvey-eula-service"));
 

--- a/lib/cloud-config-manager.ts
+++ b/lib/cloud-config-manager.ts
@@ -1,19 +1,19 @@
 import * as path from "path";
 
-export class ServerConfigManager implements ICloudConfigManager {
+export class CloudConfigManager implements ICloudConfigManager {
 	private static CONFIG_FILE_NAME: string = "config";
-	private static BASE_CONFIG_FILE_NAME: string = `${ServerConfigManager.CONFIG_FILE_NAME}-base`;
+	private static BASE_CONFIG_FILE_NAME: string = `${CloudConfigManager.CONFIG_FILE_NAME}-base`;
 
 	/* don't require logger and everything that has logger as dependency in config.js due to cyclic dependency */
 	constructor(protected $fs: IFileSystem,
 		protected $options: IProfileDir) {
-		const baseConfigPath = this.getConfigPath(ServerConfigManager.CONFIG_FILE_NAME);
+		const baseConfigPath = this.getConfigPath(CloudConfigManager.CONFIG_FILE_NAME);
 
 		let serverConfig: IServerConfig = null;
 		if (this.$fs.exists(baseConfigPath)) {
 			serverConfig = this.getCurrentConfigData();
 		} else {
-			serverConfig = this.loadConfig(ServerConfigManager.BASE_CONFIG_FILE_NAME);
+			serverConfig = this.loadConfig(CloudConfigManager.BASE_CONFIG_FILE_NAME);
 		}
 
 		this.mergeConfig(this, serverConfig);
@@ -24,10 +24,10 @@ export class ServerConfigManager implements ICloudConfigManager {
 	}
 
 	public applyConfig(configName: string, options?: IConfigOptions, globalServerConfig?: IServerConfigBase): void {
-		const baseConfig = this.loadConfig(ServerConfigManager.BASE_CONFIG_FILE_NAME);
-		const newConfig = this.loadConfig(`${ServerConfigManager.CONFIG_FILE_NAME}-${configName}`, options);
+		const baseConfig = this.loadConfig(CloudConfigManager.BASE_CONFIG_FILE_NAME);
+		const newConfig = this.loadConfig(`${CloudConfigManager.CONFIG_FILE_NAME}-${configName}`, options);
 		this.mergeConfig(baseConfig, newConfig, globalServerConfig);
-		this.saveConfig(baseConfig, ServerConfigManager.CONFIG_FILE_NAME);
+		this.saveConfig(baseConfig, CloudConfigManager.CONFIG_FILE_NAME);
 	}
 
 	public printConfigData(): void {
@@ -36,7 +36,7 @@ export class ServerConfigManager implements ICloudConfigManager {
 	}
 
 	public getCurrentConfigData(): IServerConfig {
-		return this.loadConfig(ServerConfigManager.CONFIG_FILE_NAME);
+		return this.loadConfig(CloudConfigManager.CONFIG_FILE_NAME);
 	}
 
 	public getServiceDomainName(serviceName: string): string {
@@ -64,6 +64,7 @@ export class ServerConfigManager implements ICloudConfigManager {
 
 	public getCloudServicesDomainNames(): string[] {
 		const cloudServices = this.getCurrentConfigData().cloudServices;
+
 		return _(cloudServices)
 			.keys()
 			.map(s => this.getServiceDomainName(s))
@@ -105,4 +106,4 @@ export class ServerConfigManager implements ICloudConfigManager {
 	}
 }
 
-$injector.register("nsCloudConfigManager", ServerConfigManager);
+$injector.register("nsCloudConfigManager", CloudConfigManager);

--- a/lib/commands/config/config-apply.ts
+++ b/lib/commands/config/config-apply.ts
@@ -6,15 +6,15 @@ export class ConfigApplyCommand implements ICommand {
 	}
 
 	constructor(private $nsCloudOptionsProvider: ICloudOptionsProvider,
-		private $nsCloudServerConfigManager: IServerConfigManager,
+		private $nsCloudConfigManager: ICloudConfigManager,
 		private $options: ICloudOptions,
 		private $stringParameterBuilder: IStringParameterBuilder) { }
 
 	public async execute(args: string[]): Promise<void> {
 		const configurationName = args[0];
 		const globalServerConfig: IServerConfigBase = { apiVersion: this.$options.apiVersion, serverProto: this.$options.serverProto, namespace: this.$options.namespace };
-		this.$nsCloudServerConfigManager.applyConfig(configurationName, null, globalServerConfig);
-		this.$nsCloudServerConfigManager.printConfigData();
+		this.$nsCloudConfigManager.applyConfig(configurationName, null, globalServerConfig);
+		this.$nsCloudConfigManager.printConfigData();
 	}
 }
 

--- a/lib/commands/config/config-get.ts
+++ b/lib/commands/config/config-get.ts
@@ -1,10 +1,10 @@
 export class ConfigGetCommand implements ICommand {
-	constructor(private $nsCloudServerConfigManager: IServerConfigManager) { }
+	constructor(private $nsCloudConfigManager: ICloudConfigManager) { }
 
 	public allowedParameters: ICommandParameter[] = [];
 
 	public async execute(args: string[]): Promise<void> {
-		this.$nsCloudServerConfigManager.printConfigData();
+		this.$nsCloudConfigManager.printConfigData();
 	}
 }
 

--- a/lib/commands/config/config-reset.ts
+++ b/lib/commands/config/config-reset.ts
@@ -1,11 +1,11 @@
 export class ConfigResetCommand implements ICommand {
-	constructor(private $nsCloudServerConfigManager: IServerConfigManager,
+	constructor(private $nsCloudConfigManager: ICloudConfigManager,
 		private $logger: ILogger) { }
 
 	public allowedParameters: ICommandParameter[] = [];
 
 	public async execute(args: string[]): Promise<void> {
-		this.$nsCloudServerConfigManager.reset();
+		this.$nsCloudConfigManager.reset();
 		this.$logger.info("Server configuration successfully reset.");
 	}
 }

--- a/lib/commands/config/config-set.ts
+++ b/lib/commands/config/config-set.ts
@@ -6,15 +6,15 @@ export class ConfigApplyCommand implements ICommand {
 	}
 
 	constructor(private $nsCloudOptionsProvider: ICloudOptionsProvider,
-		private $nsCloudServerConfigManager: IServerConfigManager,
+		private $nsCloudConfigManager: ICloudConfigManager,
 		private $options: ICloudOptions,
 		private $stringParameterBuilder: IStringParameterBuilder) { }
 
 	public async execute(args: string[]): Promise<void> {
 		const configurationFile = args[0];
 		const globalServerConfig: IServerConfigBase = { apiVersion: this.$options.apiVersion, serverProto: this.$options.serverProto };
-		this.$nsCloudServerConfigManager.applyConfig(null, { configurationFile }, globalServerConfig);
-		this.$nsCloudServerConfigManager.printConfigData();
+		this.$nsCloudConfigManager.applyConfig(null, { configurationFile }, globalServerConfig);
+		this.$nsCloudConfigManager.printConfigData();
 	}
 }
 

--- a/lib/definitions/cloud-config-manager.d.ts
+++ b/lib/definitions/cloud-config-manager.d.ts
@@ -1,4 +1,4 @@
-interface IServerConfigManager {
+interface ICloudConfigManager {
 	/**
 	 * Resets config.json to it's default values.
 	 * @returns {void}
@@ -8,15 +8,45 @@ interface IServerConfigManager {
 	/**
 	 * Applies specific configuration and saves it in config.json
 	 * @param {string} configName The name of the configuration to be applied.
-	 * @param optional {IConfigOptions} options The config options.
-	 * @param optional {IServerConfigBase} globalServerConfig The global server configuration which will
+	 * @param {IConfigOptions} [options] The config options.
+	 * @param {IServerConfigBase} [globalServerConfig] The global server configuration which will
 	 * be used when changing the configuration. This parameter will override the default global configuration.
 	 * @returns {void}
 	 */
 	applyConfig(configName: string, options?: IConfigOptions, globalServerConfig?: IServerConfigBase): void;
 
+	/**
+	 * Returns the current cloud configuration.
+	 * @returns {IServerConfig}
+	 */
 	getCurrentConfigData(): IServerConfig;
 
+	/**
+	 * Returns the domain of the provided cloud service.
+	 * @param serviceName The name of the cloud service.
+	 * @returns {string}
+	 */
+	getServiceDomainName(serviceName: string): string;
+
+	/**
+	 * Returns the domain names of all cloud services.
+	 * @returns {string[]} The domain names of all cloud services.
+	 */
+	getCloudServicesDomainNames(): string[];
+
+	/**
+	 * Returns the value stored in the configuration of the provided service or the default value stored in the
+	 * global configuration.
+	 * @param serviceName The name of the cloud service.
+	 * @param valueName The name of the value.
+	 * @returns {string} The value specified in the provided service config or the value specified in the global config.
+	 */
+	getServiceValueOrDefault(serviceName: string, valueName: string): string;
+
+	/**
+	 * Prints the current cloud configuration on the stdout of the process.
+	 * @returns {void}
+	 */
 	printConfigData(): void;
 }
 

--- a/lib/definitions/server/server-services.d.ts
+++ b/lib/definitions/server/server-services.d.ts
@@ -5,7 +5,6 @@ interface IRequestBodyElement {
 }
 
 interface IServerServicesProxy extends IServerRequestService {
-	getServiceAddress(serviceName: string): string;
 	getServiceProto(serviceName: string): string;
 	getUrlPath(serviceName: string, urlPath: string): string;
 }

--- a/lib/services/server/mbaas/mbaas-proxy.ts
+++ b/lib/services/server/mbaas/mbaas-proxy.ts
@@ -4,14 +4,9 @@ export class MBaasProxy extends ServerServicesProxy implements IServerServicesPr
 	constructor($errors: IErrors,
 		$httpClient: Server.IHttpClient,
 		$logger: ILogger,
-		$nsCloudServerConfigManager: IServerConfigManager,
+		$nsCloudConfigManager: ICloudConfigManager,
 		$nsCloudUserService: IUserService) {
-		super($errors, $httpClient, $logger, $nsCloudServerConfigManager, $nsCloudUserService);
-	}
-
-	public getServiceAddress(serviceName: string): string {
-		const serviceConfig = this.serverConfig.mBaaS[serviceName];
-		return serviceConfig.fullHostName;
+		super($errors, $httpClient, $logger, $nsCloudConfigManager, $nsCloudUserService);
 	}
 
 	public getUrlPath(serviceName: string, urlPath: string): string {
@@ -22,6 +17,11 @@ export class MBaasProxy extends ServerServicesProxy implements IServerServicesPr
 
 	protected getAuthScheme(serviceName: string): string {
 		return this.serverConfig.mBaaS[serviceName].authScheme || super.getAuthScheme(serviceName);
+	}
+
+	protected getServiceDomainName(serviceName: string): string {
+		const serviceConfig = this.serverConfig.mBaaS[serviceName];
+		return serviceConfig.fullHostName;
 	}
 }
 

--- a/lib/services/server/server-auth-service.ts
+++ b/lib/services/server/server-auth-service.ts
@@ -4,7 +4,8 @@ import { ServerServiceBase } from "./server-service-base";
 export class ServerAuthService extends ServerServiceBase implements IServerAuthService {
 	protected serviceName: string = AUTH_SERVICE_NAME;
 
-	constructor(protected $nsCloudServerServicesProxy: IServerServicesProxy,
+	constructor(protected $nsCloudConfigManager: ICloudConfigManager,
+		protected $nsCloudServerServicesProxy: IServerServicesProxy,
 		private $nsAccountUtils: IAccountUtils,
 		private $nsCloudUserService: IUserService,
 		$injector: IInjector) {
@@ -40,7 +41,7 @@ export class ServerAuthService extends ServerServiceBase implements IServerAuthS
 
 	private getAuthUrl(urlPath: string): string {
 		const proto = this.$nsCloudServerServicesProxy.getServiceProto(AUTH_SERVICE_NAME);
-		const host = this.$nsCloudServerServicesProxy.getServiceAddress(AUTH_SERVICE_NAME);
+		const host = this.$nsCloudConfigManager.getServiceDomainName(AUTH_SERVICE_NAME);
 		const url = this.$nsCloudServerServicesProxy.getUrlPath(AUTH_SERVICE_NAME, urlPath);
 		return `${proto}://${host}${url}`;
 	}

--- a/lib/services/user-service.ts
+++ b/lib/services/user-service.ts
@@ -2,7 +2,7 @@ export class UserService implements IUserService {
 	private userService: IUserService;
 
 	constructor(private $injector: IInjector,
-		private $nsCloudServerConfigManager: IServerConfigManager) {
+		private $nsCloudConfigManager: ICloudConfigManager) {
 		this.userService = this.determineUserService();
 	}
 
@@ -35,7 +35,7 @@ export class UserService implements IUserService {
 	}
 
 	private determineUserService(): IUserService {
-		const serverConfig = this.$nsCloudServerConfigManager.getCurrentConfigData();
+		const serverConfig = this.$nsCloudConfigManager.getCurrentConfigData();
 		const namespace: string = serverConfig["namespace"];
 		if (namespace && namespace.toLowerCase() === "kinvey") {
 			return this.$injector.resolve<IUserService>("nsCloudKinveyUserService");

--- a/server-configs/config-local.json
+++ b/server-configs/config-local.json
@@ -8,12 +8,6 @@
 		"build-service": {
 			"fullHostName": "localhost:8001"
 		},
-		"emulators-service": {
-			"fullHostName": "localhost:8002"
-		},
-		"code-commit-service": {
-			"fullHostName": "localhost:8003"
-		},
 		"misc-service": {
 			"fullHostName": "localhost:8004"
 		},

--- a/server-configs/config-production.json
+++ b/server-configs/config-production.json
@@ -7,12 +7,6 @@
 		"build-service": {
 			"subdomain": "build"
 		},
-		"emulators-service": {
-			"subdomain": "emulators"
-		},
-		"code-commit-service": {
-			"subdomain": "code-commit"
-		},
 		"misc-service": {
 			"subdomain": "misc"
 		},

--- a/server-configs/config-test.json
+++ b/server-configs/config-test.json
@@ -7,12 +7,6 @@
 		"build-service": {
 			"subdomain": "test-build"
 		},
-		"emulators-service": {
-			"subdomain": "test-emulators"
-		},
-		"code-commit-service": {
-			"subdomain": "test-code-commit"
-		},
 		"misc-service": {
 			"subdomain": "test-misc"
 		},

--- a/server-configs/config.json
+++ b/server-configs/config.json
@@ -10,12 +10,6 @@
 		"build-service": {
 			"subdomain": "build"
 		},
-		"emulators-service": {
-			"subdomain": "emulators"
-		},
-		"code-commit-service": {
-			"subdomain": "code-commit"
-		},
 		"misc-service": {
 			"subdomain": "misc"
 		},


### PR DESCRIPTION
Add `nsCloudConfigManager` to the public API. It should provide methods for managing the cloud configuration and for listing all cloud services domain names.

This PR also removes the unused cloud services.