### PR TITLE
 fix: EULA is not accepted correctly first time 

### DIFF
--- a/lib/services/eula-service-base.ts
+++ b/lib/services/eula-service-base.ts
@@ -93,7 +93,7 @@ export abstract class EulaServiceBase implements IEulaService {
 				this.$logger.trace(`The previously downloaded EULA is up-to-date`);
 			} else {
 				const lockFilePath = this.getLockFilePath("download.lock");
-				this.$nsCloudLockService.executeActionWithLock(async () => {
+				await this.$nsCloudLockService.executeActionWithLock(async () => {
 					this.$logger.trace(`Successfully downloaded EULA to ${tempEulaPath}.`);
 					this.$fs.copyFile(tempEulaPath, this.getPathToEula());
 					this.$logger.trace(`Successfully copied EULA to ${this.getPathToEula()}.`);

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "lib/bootstrap.js",
   "scripts": {
     "test": "node_modules/.bin/istanbul cover node_modules/mocha/bin/_mocha -- --recursive --reporter spec-xunit-file --require test/test-bootstrap.js --timeout 1000 test/",
-    "tslint": "tslint -p tsconfig.json --type-check -e 'node_modules/**/*'",
-    "tslint-fix": "tslint -p tsconfig.json --type-check --fix -e 'node_modules/**/*'"
+    "tslint": "tslint -p tsconfig.json -e 'node_modules/**/*'",
+    "tslint-fix": "tslint -p tsconfig.json --fix -e 'node_modules/**/*'"
   },
   "repository": {
     "type": "git",
@@ -36,15 +36,15 @@
     "grunt-contrib-copy": "1.0.0",
     "grunt-contrib-watch": "1.0.0",
     "grunt-shell": "1.3.0",
-    "grunt-ts": "6.0.0-beta.16",
+    "grunt-ts": "6.0.0-beta.22",
     "istanbul": "0.4.5",
     "mocha": "3.5.3",
     "mocha-typescript": "1.1.8",
     "nativescript": "https://github.com/NativeScript/nativescript-cli/tarball/master",
     "should": "7.0.2",
     "spec-xunit-file": "0.0.1-3",
-    "tslint": "5.7.0",
-    "typescript": "2.4.1"
+    "tslint": "5.14.0",
+    "typescript": "3.4.1"
   },
   "dependencies": {
     "aws4": "1.6.0",

--- a/tslint.json
+++ b/tslint.json
@@ -52,7 +52,6 @@
 			true,
 			"allow-null-check"
 		],
-		"typeof-compare": true,
 		"use-isnan": true,
 		"variable-name": [
 			true,


### PR DESCRIPTION
As the method for lock of accepting EULA is not awaited, first time when `tns accept eula` is called, it writes `false` in the `user-settings.json` file. So EULA is not actually accepted.
Await the execution, so correct EULA hash is written in the file.

Update devDependencies to latest TypeScript related versions as CLI had updated its own versions and current build fails. Remove `--type-check` from tslint spawn as the option is deprecated.
Remove tslint rule as it is also deprecated.