### PR TITLE
fix: do not overwrite EULA in case download returns 304

### DIFF
--- a/lib/services/eula-service-base.ts
+++ b/lib/services/eula-service-base.ts
@@ -82,16 +82,14 @@ export abstract class EulaServiceBase implements IEulaService {
 
 			const eulaFstat = this.getEulaFsStat();
 
-			await this.$httpClient.httpRequest({
+			const result = await this.$httpClient.httpRequest({
 				url: this.getEulaUrl(),
 				pipeTo: this.$fs.createWriteStream(tempEulaPath),
 				headers: eulaFstat && !opts.forceDownload ? { "If-Modified-Since": eulaFstat.mtime.toUTCString() } : {},
 				timeout: EulaConstants.timeout
 			});
 
-			if (!this.$fs.exists(tempEulaPath)) {
-				this.$logger.trace(`The previously downloaded EULA is up-to-date`);
-			} else {
+			if (result.response.statusCode !== 304) {
 				const lockFilePath = this.getLockFilePath("download.lock");
 				await this.$nsCloudLockService.executeActionWithLock(async () => {
 					this.$logger.trace(`Successfully downloaded EULA to ${tempEulaPath}.`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "1.17.2",
+  "version": "1.17.3",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {

--- a/test/services/eula-service.ts
+++ b/test/services/eula-service.ts
@@ -35,7 +35,11 @@ describe("eulaService", () => {
 
 				testInfo.actualHttpRequestIfModifiedSinceHeader = options && options.headers && options.headers["If-Modified-Since"];
 
-				return null;
+				return <any>{
+					response: {
+						statusCode: testInfo.actualHttpRequestIfModifiedSinceHeader ? 304 : 200
+					}
+				};
 			}
 		});
 


### PR DESCRIPTION
In case the http request for downloading EULA returns 304, we should not overwrite existing EULA as the downloaded file is empty.