### PR TITLE
 fix: handle CLI's changes for Ctrl + C

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -11,6 +11,7 @@ $injector.require("nsCloudEulaCommandHelper", path.join(__dirname, "commands", "
 $injector.require("nsCloudAndroidBundleValidatorHelper", path.join(__dirname, "cloud-android-bundle-validator-helper"));
 $injector.require("nsCloudKinveyUserService", path.join(__dirname, "services", "kinvey-user-service"));
 $injector.require("nsCloudLockService", path.join(__dirname, "services", "lock-service"));
+$injector.require("nsCloudProcessService", path.join(__dirname, "services", "process-service"));
 $injector.require("nsCloudTelerikUserService", path.join(__dirname, "services", "telerik-user-service"));
 $injector.require("nsCloudS3Helper", path.join(__dirname, "s3-helper"));
 

--- a/lib/commands/build-command-helper.ts
+++ b/lib/commands/build-command-helper.ts
@@ -134,7 +134,8 @@ export class BuildCommandHelper implements IBuildCommandHelper {
 				keyStorePassword: this.$options.keyStorePassword,
 				keyStorePath: this.$options.keyStorePath,
 				useHotModuleReload: this.$options.hmr,
-				env: this.$options.env
+				env: this.$options.env,
+				iCloudContainerEnvironment: this.$options.iCloudContainerEnvironment
 			}, this.$options.platformTemplate);
 		} else {
 			const buildData = this.getCloudBuildData(platform);

--- a/lib/commands/clean/clean-cloud-workspace.ts
+++ b/lib/commands/clean/clean-cloud-workspace.ts
@@ -7,14 +7,14 @@ export class CleanCloudWorkspace extends InteractiveCloudCommand implements ICom
 
 	public allowedParameters: ICommandParameter[] = [];
 
-	constructor($processService: IProcessService,
+	constructor($nsCloudProcessService: IProcessService,
 		protected $errors: IErrors,
 		protected $logger: ILogger,
 		protected $prompter: IPrompter,
 		private $nsCloudEulaCommandHelper: IEulaCommandHelper,
 		private $nsCloudProjectService: ICloudProjectService,
 		private $projectData: IProjectData) {
-		super($nsCloudProjectService, $processService, $errors, $logger, $prompter);
+		super($nsCloudProjectService, $nsCloudProcessService, $errors, $logger, $prompter);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/commands/cloud-build.ts
+++ b/lib/commands/cloud-build.ts
@@ -7,7 +7,7 @@ export class CloudBuildCommand extends InteractiveCloudCommand implements IComma
 		return this.$nsCloudOptionsProvider.dashedOptions;
 	}
 
-	constructor($processService: IProcessService,
+	constructor($nsCloudProcessService: IProcessService,
 		protected $errors: IErrors,
 		protected $logger: ILogger,
 		protected $prompter: IPrompter,
@@ -18,7 +18,7 @@ export class CloudBuildCommand extends InteractiveCloudCommand implements IComma
 		private $options: ICloudOptions,
 		private $projectData: IProjectData,
 		private $nsCloudAndroidBundleValidatorHelper: IAndroidBundleValidatorHelper) {
-		super($nsCloudBuildService, $processService, $errors, $logger, $prompter);
+		super($nsCloudBuildService, $nsCloudProcessService, $errors, $logger, $prompter);
 		this.$projectData.initializeProjectData();
 	}
 

--- a/lib/commands/cloud-codesign.ts
+++ b/lib/commands/cloud-codesign.ts
@@ -12,7 +12,7 @@ export class CloudCodesignCommand extends InteractiveCloudCommand implements ICo
 	private devices: Mobile.IDeviceInfo[];
 	public allowedParameters: ICommandParameter[];
 
-	constructor($processService: IProcessService,
+	constructor($nsCloudProcessService: IProcessService,
 		protected $errors: IErrors,
 		protected $logger: ILogger,
 		protected $prompter: IPrompter,
@@ -23,7 +23,7 @@ export class CloudCodesignCommand extends InteractiveCloudCommand implements ICo
 		private $options: ICloudOptions,
 		private $projectData: IProjectData,
 		private $nsCloudCodesignService: ICloudCodesignService) {
-		super($nsCloudCodesignService, $processService, $errors, $logger, $prompter);
+		super($nsCloudCodesignService, $nsCloudProcessService, $errors, $logger, $prompter);
 		this.$projectData.initializeProjectData();
 	}
 

--- a/lib/commands/cloud-deploy.ts
+++ b/lib/commands/cloud-deploy.ts
@@ -7,7 +7,7 @@ export class CloudDeploy extends InteractiveCloudCommand implements ICommand {
 		return this.$nsCloudOptionsProvider.dashedOptions;
 	}
 
-	constructor($processService: IProcessService,
+	constructor($nsCloudProcessService: IProcessService,
 		protected $errors: IErrors,
 		protected $logger: ILogger,
 		protected $prompter: IPrompter,
@@ -20,7 +20,7 @@ export class CloudDeploy extends InteractiveCloudCommand implements ICommand {
 		private $options: ICloudOptions,
 		private $projectData: IProjectData,
 		private $nsCloudAndroidBundleValidatorHelper: IAndroidBundleValidatorHelper) {
-		super($nsCloudBuildService, $processService, $errors, $logger, $prompter);
+		super($nsCloudBuildService, $nsCloudProcessService, $errors, $logger, $prompter);
 		this.$projectData.initializeProjectData();
 	}
 

--- a/lib/commands/cloud-dev-apple-login.ts
+++ b/lib/commands/cloud-dev-apple-login.ts
@@ -8,7 +8,7 @@ export class CloudDevAppleLogin extends InteractiveCloudCommand {
 		return this.$nsCloudOptionsProvider.dashedOptions;
 	}
 
-	constructor($processService: IProcessService,
+	constructor($nsCloudProcessService: IProcessService,
 		private $nsCloudEulaCommandHelper: IEulaCommandHelper,
 		private $nsCloudOptionsProvider: ICloudOptionsProvider,
 		private $options: ICloudOptions,
@@ -18,7 +18,7 @@ export class CloudDevAppleLogin extends InteractiveCloudCommand {
 		protected $prompter: IPrompter,
 		protected $nsCloudAppleService: ICloudAppleService,
 		protected $nsCloudBuildCommandHelper: IBuildCommandHelper) {
-		super($nsCloudAppleService, $processService, $errors, $logger, $prompter);
+		super($nsCloudAppleService, $nsCloudProcessService, $errors, $logger, $prompter);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/commands/cloud-publish.ts
+++ b/lib/commands/cloud-publish.ts
@@ -8,7 +8,7 @@ abstract class CloudPublish extends InteractiveCloudCommand {
 		return this.$nsCloudOptionsProvider.dashedOptions;
 	}
 
-	constructor($processService: IProcessService,
+	constructor($nsCloudProcessService: IProcessService,
 		private $nsCloudOptionsProvider: ICloudOptionsProvider,
 		protected $errors: IErrors,
 		protected $logger: ILogger,
@@ -18,7 +18,7 @@ abstract class CloudPublish extends InteractiveCloudCommand {
 		protected $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		protected $nsCloudAndroidBundleValidatorHelper: IAndroidBundleValidatorHelper,
 		protected $nsCloudPublishService: ICloudPublishService) {
-		super($nsCloudPublishService, $processService, $errors, $logger, $prompter);
+		super($nsCloudPublishService, $nsCloudProcessService, $errors, $logger, $prompter);
 		this.$projectData.initializeProjectData();
 	}
 
@@ -32,7 +32,7 @@ abstract class CloudPublish extends InteractiveCloudCommand {
 export class CloudPublishAndroid extends CloudPublish implements ICommand {
 	constructor($nsCloudOptionsProvider: ICloudOptionsProvider,
 		$logger: ILogger,
-		$processService: IProcessService,
+		$nsCloudProcessService: IProcessService,
 		private $nsCloudBuildCommandHelper: IBuildCommandHelper,
 		private $nsCloudEulaCommandHelper: IEulaCommandHelper,
 		protected $errors: IErrors,
@@ -43,7 +43,7 @@ export class CloudPublishAndroid extends CloudPublish implements ICommand {
 		protected $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		protected $nsCloudAndroidBundleValidatorHelper: IAndroidBundleValidatorHelper
 	) {
-		super($processService, $nsCloudOptionsProvider, $errors, $logger, $prompter, $projectData, $options, $devicePlatformsConstants, $nsCloudAndroidBundleValidatorHelper, $nsCloudPublishService);
+		super($nsCloudProcessService, $nsCloudOptionsProvider, $errors, $logger, $prompter, $projectData, $options, $devicePlatformsConstants, $nsCloudAndroidBundleValidatorHelper, $nsCloudPublishService);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {
@@ -87,7 +87,7 @@ $injector.registerCommand("cloud|publish|android", CloudPublishAndroid);
 export class CloudPublishIos extends CloudPublish implements ICommand {
 	constructor($nsCloudOptionsProvider: ICloudOptionsProvider,
 		$logger: ILogger,
-		$processService: IProcessService,
+		$nsCloudProcessService: IProcessService,
 		private $nsCloudBuildCommandHelper: IBuildCommandHelper,
 		private $nsCloudEulaCommandHelper: IEulaCommandHelper,
 		protected $errors: IErrors,
@@ -97,7 +97,7 @@ export class CloudPublishIos extends CloudPublish implements ICommand {
 		protected $options: ICloudOptions,
 		protected $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		$nsCloudAndroidBundleValidatorHelper: IAndroidBundleValidatorHelper) {
-		super($processService, $nsCloudOptionsProvider, $errors, $logger, $prompter, $projectData, $options, $devicePlatformsConstants, $nsCloudAndroidBundleValidatorHelper, $nsCloudPublishService);
+		super($nsCloudProcessService, $nsCloudOptionsProvider, $errors, $logger, $prompter, $projectData, $options, $devicePlatformsConstants, $nsCloudAndroidBundleValidatorHelper, $nsCloudPublishService);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/commands/cloud-run.ts
+++ b/lib/commands/cloud-run.ts
@@ -8,7 +8,7 @@ export class CloudRunCommand extends InteractiveCloudCommand implements ICommand
 	}
 
 	public platform: string;
-	constructor($processService: IProcessService,
+	constructor($nsCloudProcessService: IProcessService,
 		protected $errors: IErrors,
 		protected $logger: ILogger,
 		protected $prompter: IPrompter,
@@ -19,7 +19,7 @@ export class CloudRunCommand extends InteractiveCloudCommand implements ICommand
 		private $nsCloudOptionsProvider: ICloudOptionsProvider,
 		private $projectData: IProjectData,
 		private $nsCloudAndroidBundleValidatorHelper: IAndroidBundleValidatorHelper) {
-		super($nsCloudBuildService, $processService, $errors, $logger, $prompter);
+		super($nsCloudBuildService, $nsCloudProcessService, $errors, $logger, $prompter);
 		this.$projectData.initializeProjectData();
 	}
 
@@ -56,14 +56,14 @@ export class CloudRunIosCommand extends CloudRunCommand implements ICommand {
 		$nsCloudBuildCommandHelper: IBuildCommandHelper,
 		$nsCloudBuildService: ICloudBuildService,
 		$nsCloudOptionsProvider: ICloudOptionsProvider,
-		$processService: IProcessService,
+		$nsCloudProcessService: IProcessService,
 		$projectData: IProjectData,
 		$nsCloudAndroidBundleValidatorHelper: IAndroidBundleValidatorHelper,
 		protected $errors: IErrors,
 		protected $logger: ILogger,
 		protected $prompter: IPrompter,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) {
-		super($processService, $errors, $logger, $prompter, $liveSyncCommandHelper, $nsCloudEulaCommandHelper, $nsCloudBuildService, $nsCloudBuildCommandHelper, $nsCloudOptionsProvider, $projectData, $nsCloudAndroidBundleValidatorHelper);
+		super($nsCloudProcessService, $errors, $logger, $prompter, $liveSyncCommandHelper, $nsCloudEulaCommandHelper, $nsCloudBuildService, $nsCloudBuildCommandHelper, $nsCloudOptionsProvider, $projectData, $nsCloudAndroidBundleValidatorHelper);
 	}
 }
 
@@ -80,14 +80,14 @@ export class CloudRunAndroidCommand extends CloudRunCommand implements ICommand 
 		$nsCloudBuildCommandHelper: IBuildCommandHelper,
 		$nsCloudBuildService: ICloudBuildService,
 		$nsCloudOptionsProvider: ICloudOptionsProvider,
-		$processService: IProcessService,
+		$nsCloudProcessService: IProcessService,
 		$projectData: IProjectData,
 		$nsCloudAndroidBundleValidatorHelper: IAndroidBundleValidatorHelper,
 		protected $errors: IErrors,
 		protected $logger: ILogger,
 		protected $prompter: IPrompter,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) {
-		super($processService, $errors, $logger, $prompter, $liveSyncCommandHelper, $nsCloudEulaCommandHelper, $nsCloudBuildService, $nsCloudBuildCommandHelper, $nsCloudOptionsProvider, $projectData, $nsCloudAndroidBundleValidatorHelper);
+		super($nsCloudProcessService, $errors, $logger, $prompter, $liveSyncCommandHelper, $nsCloudEulaCommandHelper, $nsCloudBuildService, $nsCloudBuildCommandHelper, $nsCloudOptionsProvider, $projectData, $nsCloudAndroidBundleValidatorHelper);
 	}
 }
 

--- a/lib/commands/interactive-cloud-command.ts
+++ b/lib/commands/interactive-cloud-command.ts
@@ -7,7 +7,7 @@ export abstract class InteractiveCloudCommand implements ICommand {
 	protected predefinedAnswers: IPredefinedAnswer[];
 
 	constructor(private interactiveService: ICloudService,
-		private $processService: IProcessService,
+		private $nsCloudProcessService: IProcessService,
 		protected $errors: IErrors,
 		protected $logger: ILogger,
 		protected $prompter: IPrompter) {
@@ -42,7 +42,7 @@ export abstract class InteractiveCloudCommand implements ICommand {
 
 		this.interactiveService.on(CloudCommunicationEvents.MESSAGE, messageHandler);
 
-		this.$processService.attachToProcessExitSignals(this, () => {
+		this.$nsCloudProcessService.attachToProcessExitSignals(this, () => {
 			this.interactiveService.removeListener(CloudCommunicationEvents.MESSAGE, messageHandler);
 		});
 

--- a/lib/definitions/cloud-process-service.d.ts
+++ b/lib/definitions/cloud-process-service.d.ts
@@ -1,0 +1,4 @@
+interface IProcessService {
+	listenersCount: number;
+	attachToProcessExitSignals(context: any, callback: () => void): void;
+}

--- a/lib/services/cloud-apple-service.ts
+++ b/lib/services/cloud-apple-service.ts
@@ -15,9 +15,9 @@ export class CloudAppleService extends CloudService implements ICloudAppleServic
 		$logger: ILogger,
 		$nsCloudOperationFactory: ICloudOperationFactory,
 		$nsCloudOutputFilter: ICloudOutputFilter,
-		$processService: IProcessService,
+		$nsCloudProcessService: IProcessService,
 		private $nsCloudServerBuildService: IServerBuildService) {
-		super($errors, $fs, $httpClient, $logger, $nsCloudOperationFactory, $nsCloudOutputFilter, $processService);
+		super($errors, $fs, $httpClient, $logger, $nsCloudOperationFactory, $nsCloudOutputFilter, $nsCloudProcessService);
 	}
 
 	public async appleLogin(credentials: ICredentials): Promise<string> {

--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -20,7 +20,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		$logger: ILogger,
 		$nsCloudOperationFactory: ICloudOperationFactory,
 		$nsCloudOutputFilter: ICloudOutputFilter,
-		$processService: IProcessService,
+		$nsCloudProcessService: IProcessService,
 		private $nsCloudBuildHelper: ICloudBuildHelper,
 		private $nsCloudBuildPropertiesService: ICloudBuildPropertiesService,
 		private $mobileHelper: Mobile.IMobileHelper,
@@ -41,7 +41,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		private $staticConfig: IStaticConfig,
 		private $platformsData: IPlatformsData,
 		private $filesHashService: IFilesHashService) {
-		super($errors, $fs, $httpClient, $logger, $nsCloudOperationFactory, $nsCloudOutputFilter, $processService);
+		super($errors, $fs, $httpClient, $logger, $nsCloudOperationFactory, $nsCloudOutputFilter, $nsCloudProcessService);
 	}
 
 	public getServerOperationOutputDirectory(options: IOutputDirectoryOptions): string {

--- a/lib/services/cloud-codesign-service.ts
+++ b/lib/services/cloud-codesign-service.ts
@@ -18,11 +18,11 @@ export class CloudCodesignService extends CloudService implements ICloudCodesign
 		$logger: ILogger,
 		$nsCloudOperationFactory: ICloudOperationFactory,
 		$nsCloudOutputFilter: ICloudOutputFilter,
-		$processService: IProcessService,
+		$nsCloudProcessService: IProcessService,
 		private $nsCloudServerBuildService: IServerBuildService,
 		private $projectHelper: IProjectHelper,
 		private $projectDataService: IProjectDataService) {
-		super($errors, $fs, $httpClient, $logger, $nsCloudOperationFactory, $nsCloudOutputFilter, $processService);
+		super($errors, $fs, $httpClient, $logger, $nsCloudOperationFactory, $nsCloudOutputFilter, $nsCloudProcessService);
 	}
 
 	public async generateCodesignFiles(codesignData: ICodesignData,

--- a/lib/services/cloud-project-service.ts
+++ b/lib/services/cloud-project-service.ts
@@ -17,10 +17,10 @@ export class CloudProjectService extends CloudService implements ICloudProjectSe
 		$logger: ILogger,
 		$nsCloudOperationFactory: ICloudOperationFactory,
 		$nsCloudOutputFilter: ICloudOutputFilter,
-		$processService: IProcessService,
+		$nsCloudProcessService: IProcessService,
 		private $nsCloudServerProjectService: IServerProjectService,
 		private $projectHelper: IProjectHelper) {
-		super($errors, $fs, $httpClient, $logger, $nsCloudOperationFactory, $nsCloudOutputFilter, $processService);
+		super($errors, $fs, $httpClient, $logger, $nsCloudOperationFactory, $nsCloudOutputFilter, $nsCloudProcessService);
 	}
 
 	public getServerOperationOutputDirectory(options: IOutputDirectoryOptions): string {

--- a/lib/services/cloud-publish-service.ts
+++ b/lib/services/cloud-publish-service.ts
@@ -22,12 +22,12 @@ export class CloudPublishService extends CloudService implements ICloudPublishSe
 		$logger: ILogger,
 		$nsCloudOperationFactory: ICloudOperationFactory,
 		$nsCloudOutputFilter: ICloudOutputFilter,
-		$processService: IProcessService,
+		$nsCloudProcessService: IProcessService,
 		private $nsCloudServerBuildService: IServerBuildService,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $nsCloudUploadService: IUploadService,
 		private $projectDataService: IProjectDataService) {
-		super($errors, $fs, $httpClient, $logger, $nsCloudOperationFactory, $nsCloudOutputFilter, $processService);
+		super($errors, $fs, $httpClient, $logger, $nsCloudOperationFactory, $nsCloudOutputFilter, $nsCloudProcessService);
 	}
 
 	public async publishToItunesConnect(publishData: IItunesConnectPublishData): Promise<void> {

--- a/lib/services/cloud-service.ts
+++ b/lib/services/cloud-service.ts
@@ -17,10 +17,10 @@ export abstract class CloudService extends EventEmitter implements ICloudService
 		protected $logger: ILogger,
 		private $nsCloudOperationFactory: ICloudOperationFactory,
 		private $nsCloudOutputFilter: ICloudOutputFilter,
-		private $processService: IProcessService) {
+		private $nsCloudProcessService: IProcessService) {
 		super();
 		this.cloudOperations = Object.create(null);
-		this.$processService.attachToProcessExitSignals(this, this.cleanup.bind(this));
+		this.$nsCloudProcessService.attachToProcessExitSignals(this, this.cleanup.bind(this));
 	}
 
 	public getServerOperationOutputDirectory(options: IOutputDirectoryOptions): string {

--- a/lib/services/lock-service.ts
+++ b/lib/services/lock-service.ts
@@ -31,8 +31,8 @@ export class NsCouldLockService implements ILockService {
 		return this.cliLockService.lock(lockFilePath, lockOpts);
 	}
 
-	public unlock(lockFilePath?: string): void {
-		this.cliLockService.unlock(lockFilePath);
+	public async unlock(lockFilePath?: string): Promise<void> {
+		await this.cliLockService.unlock(lockFilePath);
 	}
 }
 

--- a/lib/services/process-service.ts
+++ b/lib/services/process-service.ts
@@ -1,0 +1,25 @@
+// TODO: Delete this once we do not support NativeScript CLI below 5.4.0
+export class CloudProcessService implements IProcessService {
+	protected get $nsCloudProcessService(): IProcessService {
+		return this.$nsCloudPolyfillService.getPolyfillObject<IProcessService>("processService", {
+			listenersCount: 0,
+			attachToProcessExitSignals: (context: any, callback: () => void): void => { /* mock */ }
+		});
+	}
+
+	constructor(private $nsCloudPolyfillService: IPolyfillService) { }
+
+	public get listenersCount(): number {
+		return this.$nsCloudProcessService.listenersCount;
+	}
+
+	public set listenersCount(value: number) {
+		this.$nsCloudProcessService.listenersCount = value;
+	}
+
+	public attachToProcessExitSignals(context: any, callback: () => void): void {
+		return this.$nsCloudProcessService.attachToProcessExitSignals(context, callback);
+	}
+}
+
+$injector.register("nsCloudProcessService", CloudProcessService);


### PR DESCRIPTION
In CLI the `processService` has been removed and the Ctrl + C signal is handled in a different manner. To make the `nativescript-cloud` compatible with both official CLI and the one in developement, introduce process-service in `nativescript-cloud` that wraps the original one, if it exists.
> This service should be removed when CLI 5.4.0 is the minimum required one.
