### PR TITLE
fix: tables output is not correct

### DIFF
--- a/lib/commands/account/account-list.ts
+++ b/lib/commands/account/account-list.ts
@@ -30,7 +30,7 @@ export class AccountListCommand extends AccountCommandBase implements ICommand {
 			output = table.toString();
 		}
 
-		this.$logger.out(output);
+		this.$logger.info(output);
 	}
 }
 

--- a/lib/commands/account/features.ts
+++ b/lib/commands/account/features.ts
@@ -34,7 +34,7 @@ export class FeaturesCommand extends AccountCommandBase implements ICommand {
 			output = table.toString();
 		}
 
-		this.$logger.out(output);
+		this.$logger.info(output);
 	}
 }
 

--- a/lib/commands/account/usage.ts
+++ b/lib/commands/account/usage.ts
@@ -66,7 +66,7 @@ export class UsageCommand extends AccountCommandBase implements ICommand {
 			output = tables.join(EOL);
 		}
 
-		this.$logger.out(output);
+		this.$logger.info(output);
 	}
 
 	private toPrettyDate(date: string): string {

--- a/lib/services/cloud-apple-service.ts
+++ b/lib/services/cloud-apple-service.ts
@@ -9,7 +9,8 @@ export class CloudAppleService extends CloudService implements ICloudAppleServic
 		return "Failed to start Apple login.";
 	}
 
-	constructor($errors: IErrors,
+	constructor($constants: IDictionary<any>,
+		$errors: IErrors,
 		$fs: IFileSystem,
 		$httpClient: Server.IHttpClient,
 		$logger: ILogger,
@@ -17,7 +18,7 @@ export class CloudAppleService extends CloudService implements ICloudAppleServic
 		$nsCloudOutputFilter: ICloudOutputFilter,
 		$nsCloudProcessService: IProcessService,
 		private $nsCloudServerBuildService: IServerBuildService) {
-		super($errors, $fs, $httpClient, $logger, $nsCloudOperationFactory, $nsCloudOutputFilter, $nsCloudProcessService);
+		super($errors, $fs, $httpClient, $logger, $constants, $nsCloudOperationFactory, $nsCloudOutputFilter, $nsCloudProcessService);
 	}
 
 	public async appleLogin(credentials: ICredentials): Promise<string> {

--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -14,7 +14,8 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		return "Failed to start cloud build.";
 	}
 
-	constructor($errors: IErrors,
+	constructor($constants: IDictionary<any>,
+		$errors: IErrors,
 		$fs: IFileSystem,
 		$httpClient: Server.IHttpClient,
 		$logger: ILogger,
@@ -41,7 +42,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		private $staticConfig: IStaticConfig,
 		private $platformsData: IPlatformsData,
 		private $filesHashService: IFilesHashService) {
-		super($errors, $fs, $httpClient, $logger, $nsCloudOperationFactory, $nsCloudOutputFilter, $nsCloudProcessService);
+		super($errors, $fs, $httpClient, $logger, $constants, $nsCloudOperationFactory, $nsCloudOutputFilter, $nsCloudProcessService);
 	}
 
 	public getServerOperationOutputDirectory(options: IOutputDirectoryOptions): string {

--- a/lib/services/cloud-codesign-service.ts
+++ b/lib/services/cloud-codesign-service.ts
@@ -12,7 +12,8 @@ export class CloudCodesignService extends CloudService implements ICloudCodesign
 		return "Failed to start generation of codesign files.";
 	}
 
-	constructor($errors: IErrors,
+	constructor($constants: IDictionary<any>,
+		$errors: IErrors,
 		$fs: IFileSystem,
 		$httpClient: Server.IHttpClient,
 		$logger: ILogger,
@@ -22,7 +23,7 @@ export class CloudCodesignService extends CloudService implements ICloudCodesign
 		private $nsCloudServerBuildService: IServerBuildService,
 		private $projectHelper: IProjectHelper,
 		private $projectDataService: IProjectDataService) {
-		super($errors, $fs, $httpClient, $logger, $nsCloudOperationFactory, $nsCloudOutputFilter, $nsCloudProcessService);
+		super($errors, $fs, $httpClient, $logger, $constants, $nsCloudOperationFactory, $nsCloudOutputFilter, $nsCloudProcessService);
 	}
 
 	public async generateCodesignFiles(codesignData: ICodesignData,

--- a/lib/services/cloud-project-service.ts
+++ b/lib/services/cloud-project-service.ts
@@ -11,7 +11,8 @@ export class CloudProjectService extends CloudService implements ICloudProjectSe
 		return "Failed to start cloud cleanup.";
 	}
 
-	constructor($errors: IErrors,
+	constructor($constants: IDictionary<any>,
+		$errors: IErrors,
 		$fs: IFileSystem,
 		$httpClient: Server.IHttpClient,
 		$logger: ILogger,
@@ -20,7 +21,7 @@ export class CloudProjectService extends CloudService implements ICloudProjectSe
 		$nsCloudProcessService: IProcessService,
 		private $nsCloudServerProjectService: IServerProjectService,
 		private $projectHelper: IProjectHelper) {
-		super($errors, $fs, $httpClient, $logger, $nsCloudOperationFactory, $nsCloudOutputFilter, $nsCloudProcessService);
+		super($errors, $fs, $httpClient, $logger, $constants, $nsCloudOperationFactory, $nsCloudOutputFilter, $nsCloudProcessService);
 	}
 
 	public getServerOperationOutputDirectory(options: IOutputDirectoryOptions): string {

--- a/lib/services/cloud-publish-service.ts
+++ b/lib/services/cloud-publish-service.ts
@@ -16,7 +16,8 @@ export class CloudPublishService extends CloudService implements ICloudPublishSe
 		return "Failed to start publishing.";
 	}
 
-	constructor($errors: IErrors,
+	constructor($constants: IDictionary<any>,
+		$errors: IErrors,
 		$fs: IFileSystem,
 		$httpClient: Server.IHttpClient,
 		$logger: ILogger,
@@ -27,7 +28,7 @@ export class CloudPublishService extends CloudService implements ICloudPublishSe
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $nsCloudUploadService: IUploadService,
 		private $projectDataService: IProjectDataService) {
-		super($errors, $fs, $httpClient, $logger, $nsCloudOperationFactory, $nsCloudOutputFilter, $nsCloudProcessService);
+		super($errors, $fs, $httpClient, $logger, $constants, $nsCloudOperationFactory, $nsCloudOutputFilter, $nsCloudProcessService);
 	}
 
 	public async publishToItunesConnect(publishData: IItunesConnectPublishData): Promise<void> {

--- a/lib/services/cloud-service.ts
+++ b/lib/services/cloud-service.ts
@@ -15,6 +15,7 @@ export abstract class CloudService extends EventEmitter implements ICloudService
 		protected $fs: IFileSystem,
 		protected $httpClient: Server.IHttpClient,
 		protected $logger: ILogger,
+		private $constants: IDictionary<any>,
 		private $nsCloudOperationFactory: ICloudOperationFactory,
 		private $nsCloudOutputFilter: ICloudOutputFilter,
 		private $nsCloudProcessService: IProcessService) {
@@ -74,9 +75,7 @@ export abstract class CloudService extends EventEmitter implements ICloudService
 				}
 
 				if (body.pipe === "stdout") {
-					// Print the output on the same line to have cool effects like loading indicators.
-					// The cloud process will take care of the new lines.
-					this.$logger.printInfoMessageOnSameLine(log);
+					this.printMessageOnTheSameLine(log);
 				} else if (body.pipe === "stderr") {
 					this.$logger.error(log);
 				}
@@ -159,6 +158,18 @@ export abstract class CloudService extends EventEmitter implements ICloudService
 			delete this.cloudOperations[cloudOperationId];
 		} catch (err) {
 			this.$logger.error(`Cloud operation ${cloudOperationId} failed with error: ${err.message}`);
+		}
+	}
+
+	private printMessageOnTheSameLine(msg: string): void {
+		const logger: any = this.$logger;
+		// Print the output on the same line to have cool effects like loading indicators.
+		// The cloud process will take care of the new lines.
+		if (logger.printInfoMessageOnSameLine) {
+			// Used in CLI before 6.0.0
+			logger.printInfoMessageOnSameLine(msg);
+		} else {
+			this.$logger.info(msg, {[this.$constants.LoggerConfigData.skipNewLine]: true });
 		}
 	}
 }


### PR DESCRIPTION
Due to latest CLI changes, some logger APIs have been deprecated. Use correct new APIs.
Also using `logger.out` prints tables incorrectly - use `logger.info` which is the correct way now.
NOTE: For example output of `tns account` was not showing table at all. This is fixed now.