### PR TITLE
fix: cloud build should use same bundle options as locally

### DIFF
--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -125,6 +125,10 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 			additionalCliFlags.push("--hmr");
 		}
 
+		if (!projectSettings.bundle && !projectSettings.useHotModuleReload) {
+			additionalCliFlags.push("--no-bundle");
+		}
+
 		if (projectSettings.env) {
 			const envOptions = _.map(projectSettings.env, (value, key) => `--env.${key}=${value}`);
 			additionalCliFlags.push(...envOptions);

--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -123,6 +123,8 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 
 		if (projectSettings.useHotModuleReload) {
 			additionalCliFlags.push("--hmr");
+		} else {
+			additionalCliFlags.push("--no-hmr");
 		}
 
 		if (!projectSettings.bundle && !projectSettings.useHotModuleReload) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "1.17.5",
+  "version": "1.17.6",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {


### PR DESCRIPTION
Currently in case you do not want to use webpack for your build (in Sidekick for example), we do not pass any bundle related options to the cloud. However, all new projects have `nsoconfig.json` in which we set that we want to use hmr workflow.
So once the project is uploaded in the cloud, we'll build it with webpack. The local prepare will not use webpack.
This breaks the LiveSync for Android, which directly syncs the files in the application on device. As the cloud build is with webpack we have `bundle.js`, `vendor.js`, etc. there. Syncing files like `main-view-model.js` is not respected when the application is started as the entry point of the build application points to starter.js file.
For iOS this works as once the application is built, we livesync the locally prepared files on device in another directory and runtime loads them from there.

As a solution, pass `--no-bundle` to the cloud when both bundle and hmr are false, so the application will be build correctly in the cloud.