### PR TITLE
fix: publish commands fail to build app

### DIFF
--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -90,7 +90,8 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		await this.$nsCloudBuildPropertiesService.validateBuildProperties(platform, buildConfiguration, projectSettings.projectId, androidBuildData, iOSBuildData);
 		await this.prepareProject(cloudOperationId, projectSettings, platform, buildConfiguration, iOSBuildData);
 		let buildFiles: IServerItemBase[] = [];
-		if (this.$mobileHelper.isAndroidPlatform(platform) && this.$nsCloudBuildHelper.isReleaseConfiguration(buildConfiguration)) {
+		const isReleaseBuild = this.$nsCloudBuildHelper.isReleaseConfiguration(buildConfiguration);
+		if (this.$mobileHelper.isAndroidPlatform(platform) && isReleaseBuild) {
 			buildFiles.push({
 				filename: uuid.v4(),
 				fullPath: androidBuildData.pathToCertificate,
@@ -119,7 +120,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 			additionalCliFlags.push("--bundle");
 		}
 
-		if (projectSettings.useHotModuleReload) {
+		if (projectSettings.useHotModuleReload && !isReleaseBuild) {
 			additionalCliFlags.push("--hmr");
 		} else {
 			additionalCliFlags.push("--no-hmr");

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@types/chai": "4.0.1",
     "@types/chai-as-promised": "0.0.31",
+    "@types/minimatch": "3.0.3",
     "@types/node": "8.10.30",
     "@types/node-forge": "0.6.7",
     "@types/promise-retry": "1.1.3",


### PR DESCRIPTION
Currently publish commands fail to build the application when `useLegacyWorkflow` is set to false in nsconfig.json. The error happens during project preparation in the cloud with error `The options --release and --hmr cannot be used simultaneously`.
This happens as by default we do not pass `--release` to cloud publish commands, so CLI does not set `options.hmr` to false. So in the cloud we send both `--release` and `--hmr` options and the build fails.
To fix this, set `--no-hmr` when we build in release configuration.