### PR TITLE
fix: don't call prepare method twice on livesync related commands

### DIFF
--- a/lib/commands/cloud-build.ts
+++ b/lib/commands/cloud-build.ts
@@ -43,7 +43,8 @@ export class CloudBuildCommand extends InteractiveCloudCommand implements IComma
 			buildData.platform, buildData.buildConfiguration,
 			this.$options.accountId,
 			buildData.androidBuildData,
-			buildData.iOSBuildData);
+			buildData.iOSBuildData,
+			{ shouldPrepare: true });
 	}
 }
 

--- a/lib/definitions/cloud-build-service.d.ts
+++ b/lib/definitions/cloud-build-service.d.ts
@@ -112,7 +112,8 @@ interface ICloudBuildService extends ICloudService {
 		buildConfiguration: string,
 		accountId: string,
 		androidBuildData?: IAndroidBuildData,
-		iOSBuildData?: IIOSBuildData): Promise<IBuildResultData>;
+		iOSBuildData?: IIOSBuildData,
+		buildOptions?: IBuildOptions): Promise<IBuildResultData>;
 
 	/**
 	 * Validates the build properties for specified platform (Android or iOS).
@@ -278,4 +279,8 @@ interface IIOSBuildData extends IBuildForDevice {
  * Here only for backwards compatibility. Deleting this will require a major version change as it is used in NativeScript Sidekick.
  */
 interface ICloudBuildOutputDirectoryOptions extends IOutputDirectoryOptions {
+}
+
+interface IBuildOptions {
+	shouldPrepare: boolean;
 }

--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -64,12 +64,14 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		buildConfiguration: string,
 		accountId: string,
 		androidBuildData?: IAndroidBuildData,
-		iOSBuildData?: IIOSBuildData): Promise<IBuildResultData> {
+		iOSBuildData?: IIOSBuildData,
+		buildOptions?: IBuildOptions): Promise<IBuildResultData> {
 		const result = await this.executeCloudOperation("Cloud build", async (cloudOperationId: string): Promise<IBuildResultData> => {
 			this.$logger.info("Getting accounts information...");
 			const account = await this.$nsCloudAccountsService.getAccountFromOption(accountId);
 			this.$logger.info("Using account %s.", account.id);
-			const buildResult = await this.executeBuild(projectSettings, platform, buildConfiguration, cloudOperationId, account.id, androidBuildData, iOSBuildData);
+
+			const buildResult = await this.executeBuild(projectSettings, platform, buildConfiguration, cloudOperationId, account.id, androidBuildData, iOSBuildData, buildOptions);
 			return buildResult;
 		});
 
@@ -82,13 +84,16 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		cloudOperationId: string,
 		accountId: string,
 		androidBuildData?: IAndroidBuildData,
-		iOSBuildData?: IIOSBuildData): Promise<IBuildResultData> {
+		iOSBuildData?: IIOSBuildData,
+		buildOptions?: IBuildOptions): Promise<IBuildResultData> {
 		const buildInformationString = `Cloud build of '${projectSettings.projectDir}', platform: '${platform}', ` +
 			`configuration: '${buildConfiguration}'`;
 		this.$logger.info(`${buildInformationString}.`);
 
 		await this.$nsCloudBuildPropertiesService.validateBuildProperties(platform, buildConfiguration, projectSettings.projectId, androidBuildData, iOSBuildData);
-		await this.prepareProject(cloudOperationId, projectSettings, platform, buildConfiguration, iOSBuildData);
+		if (buildOptions && buildOptions.shouldPrepare) {
+			await this.prepareProject(cloudOperationId, projectSettings, platform, buildConfiguration, iOSBuildData);
+		}
 		let buildFiles: IServerItemBase[] = [];
 		const isReleaseBuild = this.$nsCloudBuildHelper.isReleaseConfiguration(buildConfiguration);
 		if (this.$mobileHelper.isAndroidPlatform(platform) && isReleaseBuild) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "1.18.0",
+  "version": "1.18.1-2019-07-12-01",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {


### PR DESCRIPTION
CLI 6.0 prepares the project on initial sync for all livesync related commands and the `nativescript-cloud` tries to prepare it again. Hopefully there is a caching based on the platforms for which the webpack compilation is started. This way, a second webpack compilation is not started, but the prepare method is called for the second time. This led to the problem that nativePrepare method is called twice. However, for cloud related operations (when `skipNativePreapare` is true), `prepareNativePlatform` method only checks if there are changes in the project. This way, `checkForChanges` method is called twice. In order to remove the second `checkForChanges` we can remove preparing the project from cloud lib. This will led to the issue that if `tns cloud build ` command is executed and after that `tns cloud run`, the project will be built again. In order to avoid this behavior, we'll force the project preparation on `tns cloud build` command.