### PR TITLE
Support aab build flag

### DIFF
--- a/lib/cloud-operation/cloud-operation-v1.ts
+++ b/lib/cloud-operation/cloud-operation-v1.ts
@@ -12,6 +12,7 @@ class CloudOperationV1 extends CloudOperationBase implements ICloudOperation {
 	private serverStatus: IServerStatus;
 	private statusCheckInterval: NodeJS.Timer;
 	private logsCheckInterval: NodeJS.Timer;
+	private snoozeLogPoll: Boolean;
 
 	constructor(public id: string,
 		protected serverResponse: IServerResponse,
@@ -79,7 +80,13 @@ class CloudOperationV1 extends CloudOperationBase implements ICloudOperation {
 
 	private pollForLogs(): void {
 		this.logsCheckInterval = setInterval(async () => {
+			if (this.snoozeLogPoll) {
+				return;
+			}
+
+			this.snoozeLogPoll = true;
 			await this.getCloudOperationLogs();
+			this.snoozeLogPoll = false;
 
 			const status = this.serverStatus.status;
 			if (status === CloudOperationBase.OPERATION_COMPLETE_STATUS || status === CloudOperationBase.OPERATION_FAILED_STATUS) {

--- a/lib/cloud-operation/cloud-operation-v1.ts
+++ b/lib/cloud-operation/cloud-operation-v1.ts
@@ -12,8 +12,8 @@ class CloudOperationV1 extends CloudOperationBase implements ICloudOperation {
 	private serverStatus: IServerStatus;
 	private statusCheckInterval: NodeJS.Timer;
 	private logsCheckInterval: NodeJS.Timer;
-	private snoozeLogPoll: Boolean;
-	private hasLogPollCompleted: Boolean;
+	private snoozeLogPoll: boolean;
+	private hasLogPollCompleted: boolean;
 
 	constructor(public id: string,
 		protected serverResponse: IServerResponse,
@@ -56,8 +56,8 @@ class CloudOperationV1 extends CloudOperationBase implements ICloudOperation {
 	protected async waitForResultCore(): Promise<ICloudOperationResult> {
 		return new Promise<ICloudOperationResult>((resolve, reject) => {
 			this.statusCheckInterval = setInterval(async () => {
-				const status = this.serverStatus.status;
-				if (status !== CloudOperationV1.OPERATION_COMPLETE_STATUS && status !== CloudOperationV1.OPERATION_FAILED_STATUS) {
+				const status = this.serverStatus && this.serverStatus.status;
+				if (status === CloudOperationV1.OPERATION_IN_PROGRESS_STATUS) {
 					this.serverStatus = await this.$nsCloudS3Helper.getJsonObjectFromS3File<IServerStatus>(this.serverResponse.statusUrl);
 				}
 
@@ -93,8 +93,7 @@ class CloudOperationV1 extends CloudOperationBase implements ICloudOperation {
 				return;
 			}
 
-			const status = this.serverStatus.status;
-			const hasCompleted = status === CloudOperationBase.OPERATION_COMPLETE_STATUS || status === CloudOperationBase.OPERATION_FAILED_STATUS;
+			const hasCompleted = this.serverStatus.status !== CloudOperationBase.OPERATION_IN_PROGRESS_STATUS;
 			if (hasCompleted) {
 				clearInterval(this.logsCheckInterval);
 			}

--- a/lib/commands/build-command-helper.ts
+++ b/lib/commands/build-command-helper.ts
@@ -68,8 +68,7 @@ export class BuildCommandHelper implements IBuildCommandHelper {
 			workflowUrl: this.$options.workflow && this.$options.workflow.url,
 			clean: this.$options.clean,
 			env: this.$options.env,
-			useHotModuleReload: this.$options.hmr,
-			aab: this.$options.aab
+			useHotModuleReload: this.$options.hmr
 		};
 
 		const buildConfiguration = this.$options.release ? CLOUD_BUILD_CONFIGURATIONS.RELEASE : CLOUD_BUILD_CONFIGURATIONS.DEBUG;
@@ -79,7 +78,8 @@ export class BuildCommandHelper implements IBuildCommandHelper {
 			buildConfiguration,
 			androidBuildData: <any>{
 				pathToCertificate,
-				certificatePassword: this.$options.keyStorePassword
+				certificatePassword: this.$options.keyStorePassword,
+				aab: this.$options.aab
 			},
 			iOSBuildData: {
 				pathToCertificate,

--- a/lib/commands/build-command-helper.ts
+++ b/lib/commands/build-command-helper.ts
@@ -68,7 +68,8 @@ export class BuildCommandHelper implements IBuildCommandHelper {
 			workflowUrl: this.$options.workflow && this.$options.workflow.url,
 			clean: this.$options.clean,
 			env: this.$options.env,
-			useHotModuleReload: this.$options.hmr
+			useHotModuleReload: this.$options.hmr,
+			aab: this.$options.aab
 		};
 
 		const buildConfiguration = this.$options.release ? CLOUD_BUILD_CONFIGURATIONS.RELEASE : CLOUD_BUILD_CONFIGURATIONS.DEBUG;

--- a/lib/commands/cloud-build.ts
+++ b/lib/commands/cloud-build.ts
@@ -16,15 +16,13 @@ export class CloudBuildCommand extends InteractiveCloudCommand implements IComma
 		private $nsCloudBuildService: ICloudBuildService,
 		private $nsCloudOptionsProvider: ICloudOptionsProvider,
 		private $options: ICloudOptions,
-		private $projectData: IProjectData,
-		private $nsCloudAndroidBundleValidatorHelper: IAndroidBundleValidatorHelper) {
+		private $projectData: IProjectData) {
 		super($nsCloudBuildService, $nsCloudProcessService, $nsCloudErrorsService, $logger, $prompter);
 		this.$projectData.initializeProjectData();
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {
 		await this.$nsCloudEulaCommandHelper.ensureEulaIsAccepted();
-		this.$nsCloudAndroidBundleValidatorHelper.validateNoAab();
 
 		if (!args || !args.length) {
 			this.$nsCloudErrorsService.failWithHelp("Provide platform.");

--- a/lib/definitions/cloud-build-service.d.ts
+++ b/lib/definitions/cloud-build-service.d.ts
@@ -285,6 +285,10 @@ interface IIOSBuildData extends IBuildForDevice {
 interface ICloudBuildOutputDirectoryOptions extends IOutputDirectoryOptions {
 }
 
+interface ICloudBuildOutputOptions extends IOutputDirectoryOptions {
+	extension?: string;
+}
+
 interface IBuildOptions {
 	shouldPrepare: boolean;
 }

--- a/lib/definitions/cloud-build-service.d.ts
+++ b/lib/definitions/cloud-build-service.d.ts
@@ -203,14 +203,10 @@ interface IBundle {
 	bundle: boolean;
 }
 
-interface IAndroidBundleOptions {
-	aab: boolean;
-}
-
 /**
  * Describes the project settings required for different operations.
  */
-interface INSCloudProjectSettings extends IEnvOptions, IBundle, IAndroidBundleOptions, ISharedCloud, IProjectNameComposition, IWorkflowRequestData, IHasUseHotModuleReloadOption {
+interface INSCloudProjectSettings extends IEnvOptions, IBundle, ISharedCloud, IProjectNameComposition, IWorkflowRequestData, IHasUseHotModuleReloadOption {
 	/**
 	 * The directory where the project is located. This should be the path to the directory where application's package.json is located.
 	 */
@@ -250,6 +246,11 @@ interface IAndroidBuildData {
 	 * Password of the specified certificate. Required and used only for release builds.
 	 */
 	certificatePassword: string;
+
+	/**
+	 * Android App Bundle (--aab) option.
+	 */
+	aab?: string;
 }
 
 /**

--- a/lib/definitions/cloud-build-service.d.ts
+++ b/lib/definitions/cloud-build-service.d.ts
@@ -203,10 +203,14 @@ interface IBundle {
 	bundle: boolean;
 }
 
+interface IAndroidBundleOptions {
+	aab: boolean;
+}
+
 /**
  * Describes the project settings required for different operations.
  */
-interface INSCloudProjectSettings extends IEnvOptions, IBundle, ISharedCloud, IProjectNameComposition, IWorkflowRequestData, IHasUseHotModuleReloadOption {
+interface INSCloudProjectSettings extends IEnvOptions, IBundle, IAndroidBundleOptions, ISharedCloud, IProjectNameComposition, IWorkflowRequestData, IHasUseHotModuleReloadOption {
 	/**
 	 * The directory where the project is located. This should be the path to the directory where application's package.json is located.
 	 */

--- a/lib/definitions/cloud-build-service.d.ts
+++ b/lib/definitions/cloud-build-service.d.ts
@@ -250,7 +250,7 @@ interface IAndroidBuildData {
 	/**
 	 * Android App Bundle (--aab) option.
 	 */
-	aab?: string;
+	aab?: boolean;
 }
 
 /**
@@ -286,7 +286,7 @@ interface IIOSBuildData extends IBuildForDevice {
 interface ICloudBuildOutputDirectoryOptions extends IOutputDirectoryOptions {
 }
 
-interface ICloudBuildOutputOptions extends IOutputDirectoryOptions {
+interface ICloudOperationOutputOptions extends IOutputDirectoryOptions {
 	extension?: string;
 }
 

--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -135,6 +135,10 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 			additionalCliFlags.push("--no-bundle");
 		}
 
+		if (projectSettings.aab) {
+			additionalCliFlags.push("--aab");
+		}
+
 		if (projectSettings.env) {
 			const envOptions = _.map(projectSettings.env, (value, key) => `--env.${key}=${value}`);
 			additionalCliFlags.push(...envOptions);

--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -180,7 +180,8 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		const localBuildResult = await this.downloadServerResult(cloudOperationId, buildResult, {
 			projectDir: projectSettings.projectDir,
 			platform,
-			emulator: iOSBuildData && !iOSBuildData.buildForDevice
+			emulator: iOSBuildData && !iOSBuildData.buildForDevice,
+			extension: projectSettings.aab ? "aab" : null
 		});
 
 		this.$logger.info(`The result of ${buildInformationString} successfully downloaded. OutputFilePath: ${localBuildResult}`);
@@ -369,7 +370,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		return [result];
 	}
 
-	private async downloadServerResult(cloudOperationId: string, buildResult: ICloudOperationResult, buildOutputOptions: IOutputDirectoryOptions): Promise<string> {
+	private async downloadServerResult(cloudOperationId: string, buildResult: ICloudOperationResult, buildOutputOptions: ICloudBuildOutputOptions): Promise<string> {
 		this.emitStepChanged(cloudOperationId, constants.BUILD_STEP_NAME.DOWNLOAD, constants.BUILD_STEP_PROGRESS.START);
 		const targetFileNames = await super.downloadServerResults(buildResult, buildOutputOptions);
 		this.emitStepChanged(cloudOperationId, constants.BUILD_STEP_NAME.DOWNLOAD, constants.BUILD_STEP_PROGRESS.END);

--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -135,7 +135,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 			additionalCliFlags.push("--no-bundle");
 		}
 
-		if (androidBuildData.aab) {
+		if (androidBuildData && androidBuildData.aab) {
 			additionalCliFlags.push("--aab");
 		}
 
@@ -181,7 +181,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 			projectDir: projectSettings.projectDir,
 			platform,
 			emulator: iOSBuildData && !iOSBuildData.buildForDevice,
-			extension: androidBuildData.aab ? "aab" : null
+			extension: androidBuildData && androidBuildData.aab ? "aab" : null
 		});
 
 		this.$logger.info(`The result of ${buildInformationString} successfully downloaded. OutputFilePath: ${localBuildResult}`);
@@ -370,7 +370,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 		return [result];
 	}
 
-	private async downloadServerResult(cloudOperationId: string, buildResult: ICloudOperationResult, buildOutputOptions: ICloudBuildOutputOptions): Promise<string> {
+	private async downloadServerResult(cloudOperationId: string, buildResult: ICloudOperationResult, buildOutputOptions: ICloudOperationOutputOptions): Promise<string> {
 		this.emitStepChanged(cloudOperationId, constants.BUILD_STEP_NAME.DOWNLOAD, constants.BUILD_STEP_PROGRESS.START);
 		const targetFileNames = await super.downloadServerResults(buildResult, buildOutputOptions);
 		this.emitStepChanged(cloudOperationId, constants.BUILD_STEP_NAME.DOWNLOAD, constants.BUILD_STEP_PROGRESS.END);

--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -135,7 +135,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 			additionalCliFlags.push("--no-bundle");
 		}
 
-		if (projectSettings.aab) {
+		if (androidBuildData.aab) {
 			additionalCliFlags.push("--aab");
 		}
 
@@ -181,7 +181,7 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 			projectDir: projectSettings.projectDir,
 			platform,
 			emulator: iOSBuildData && !iOSBuildData.buildForDevice,
-			extension: projectSettings.aab ? "aab" : null
+			extension: androidBuildData.aab ? "aab" : null
 		});
 
 		this.$logger.info(`The result of ${buildInformationString} successfully downloaded. OutputFilePath: ${localBuildResult}`);

--- a/lib/services/cloud-service.ts
+++ b/lib/services/cloud-service.ts
@@ -110,7 +110,7 @@ export abstract class CloudService extends EventEmitter implements ICloudService
 		}
 	}
 
-	protected async downloadServerResults(serverResult: ICloudOperationResult, serverOutputOptions: IOutputDirectoryOptions): Promise<string[]> {
+	protected async downloadServerResults(serverResult: ICloudOperationResult, serverOutputOptions: ICloudBuildOutputOptions): Promise<string[]> {
 		const destinationDir = this.getServerOperationOutputDirectory(serverOutputOptions);
 		this.$fs.ensureDirectoryExists(destinationDir);
 
@@ -119,7 +119,13 @@ export abstract class CloudService extends EventEmitter implements ICloudService
 		let targetFileNames: string[] = [];
 		for (const serverResultObj of serverResultObjs) {
 			this.$logger.info(`Result url: ${serverResultObj.fullPath}`);
-			const targetFileName = path.join(destinationDir, serverResultObj.filename);
+
+			let filename = serverResultObj.filename;
+			if (serverOutputOptions.extension) {
+				filename = `${path.parse(filename).name}.${serverOutputOptions.extension}`;
+			}
+
+			const targetFileName = path.join(destinationDir, filename);
 			targetFileNames.push(targetFileName);
 			const targetFile = this.$fs.createWriteStream(targetFileName);
 

--- a/lib/services/cloud-service.ts
+++ b/lib/services/cloud-service.ts
@@ -110,8 +110,8 @@ export abstract class CloudService extends EventEmitter implements ICloudService
 		}
 	}
 
-	protected async downloadServerResults(serverResult: ICloudOperationResult, serverOutputOptions: ICloudBuildOutputOptions): Promise<string[]> {
-		const destinationDir = this.getServerOperationOutputDirectory(serverOutputOptions);
+	protected async downloadServerResults(serverResult: ICloudOperationResult, outputOptions: ICloudOperationOutputOptions): Promise<string[]> {
+		const destinationDir = this.getServerOperationOutputDirectory(outputOptions);
 		this.$fs.ensureDirectoryExists(destinationDir);
 
 		const serverResultObjs = this.getServerResults(serverResult);
@@ -121,8 +121,8 @@ export abstract class CloudService extends EventEmitter implements ICloudService
 			this.$logger.info(`Result url: ${serverResultObj.fullPath}`);
 
 			let filename = serverResultObj.filename;
-			if (serverOutputOptions.extension) {
-				filename = `${path.parse(filename).name}.${serverOutputOptions.extension}`;
+			if (outputOptions.extension) {
+				filename = `${path.parse(filename).name}.${outputOptions.extension}`;
 			}
 
 			const targetFileName = path.join(destinationDir, filename);


### PR DESCRIPTION
1. Add support for `--aab` flag for `tns cloud build`
2. Snooze log polling so that two subsequent polls do not overlap.
3. After the cloud build completes, check if new logs were generated between the last poll and the operation status change.