### PR TITLE
Remove qr data aab

### DIFF
--- a/lib/commands/build-command-helper.ts
+++ b/lib/commands/build-command-helper.ts
@@ -135,11 +135,13 @@ export class BuildCommandHelper implements IBuildCommandHelper {
 		} else {
 			const buildData = this.getCloudBuildData(platform);
 			buildData.buildConfiguration = CLOUD_BUILD_CONFIGURATIONS.RELEASE;
-			packagePath = (await this.$nsCloudBuildService.build(buildData.projectSettings,
+			const cloudResult = await this.$nsCloudBuildService.build(buildData.projectSettings,
 				buildData.platform, buildData.buildConfiguration,
 				this.$options.accountId,
 				buildData.androidBuildData,
-				buildData.iOSBuildData)).qrData.originalUrl;
+				buildData.iOSBuildData);
+
+			packagePath = cloudResult.qrData ? cloudResult.qrData.originalUrl : cloudResult.outputFilePath;
 		}
 
 		return packagePath;

--- a/lib/services/cloud-build-service.ts
+++ b/lib/services/cloud-build-service.ts
@@ -188,23 +188,28 @@ export class CloudBuildService extends CloudService implements ICloudBuildServic
 
 		this.$logger.info(`The result of ${buildInformationString} successfully downloaded. OutputFilePath: ${localBuildResult}`);
 
-		const buildResultUrl = this.getBuildResultUrl(buildResult);
-		const itmsOptions = {
-			pathToProvision: iOSBuildData && iOSBuildData.pathToProvision,
-			projectId: projectSettings.projectId,
-			projectName: projectSettings.projectName,
-			url: buildResultUrl
-		};
+		let qrData: IQrData = null;
+		if (!useAabFlag) {
+			const buildResultUrl = this.getBuildResultUrl(buildResult);
+			const itmsOptions = {
+				pathToProvision: iOSBuildData && iOSBuildData.pathToProvision,
+				projectId: projectSettings.projectId,
+				projectName: projectSettings.projectName,
+				url: buildResultUrl
+			};
+
+			qrData = {
+				originalUrl: buildResultUrl,
+				imageData: await this.getImageData(buildResultUrl, itmsOptions)
+			};
+		}
 
 		const result = {
 			cloudOperationId: cloudOperationId,
 			stderr: buildResult.stderr,
 			stdout: buildResult.stdout,
 			outputFilePath: localBuildResult,
-			qrData: {
-				originalUrl: buildResultUrl,
-				imageData: await this.getImageData(buildResultUrl, itmsOptions)
-			}
+			qrData
 		};
 
 		// In case HMR is passed, do not save the hashes as the files generated in the cloud may differ from the local ones.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {


### PR DESCRIPTION
Do not generate `qrData` after cloud build with `aab` flag. A user cannot download and install an aab package directly on an Android device as they can with an apk package, so the `qrData` is irrelevant. Additionally, the `originalUrl`, returned as part of the `qrData` is incorrect as it points to an apk file. We rename this apk file as part of the download step of a cloud build operation, so the local file has the correct extension, but the URL is incorrect for the user.