### PR TITLE
fix: fix cloud publish

### DIFF
--- a/lib/commands/build-command-helper.ts
+++ b/lib/commands/build-command-helper.ts
@@ -139,7 +139,8 @@ export class BuildCommandHelper implements IBuildCommandHelper {
 				buildData.platform, buildData.buildConfiguration,
 				this.$options.accountId,
 				buildData.androidBuildData,
-				buildData.iOSBuildData);
+				buildData.iOSBuildData,
+				{ shouldPrepare: true });
 
 			packagePath = cloudResult.qrData ? cloudResult.qrData.originalUrl : cloudResult.outputFilePath;
 		}


### PR DESCRIPTION
Currently when `tns cloud publish ios` command is executed, the following error is thrown:
```
TypeError: Cannot read property 'changesRequireBuildTime' of null
    at BuildInfoFileService.saveLocalBuildInfo (C:\Users\bdtest.PROGRESS\AppData\Roaming\npm\node_modules\nativescript\lib\services\build-info-file-service.js:51:38)
    at CloudPlatformService.<anonymous> (C:\Users\bdtest.PROGRESS\AppData\Roaming\.nativescript-cli\extensions\node_modules\nativescript-cloud\lib\services\cloud-platform-service.js:68:42)
    at Generator.next (<anonymous>)
    at C:\Users\bdtest.PROGRESS\AppData\Roaming\.nativescript-cli\extensions\node_modules\nativescript-cloud\lib\services\cloud-platform-service.js:7:71
    at new Promise (<anonymous>)
    at __awaiter (C:\Users\bdtest.PROGRESS\AppData\Roaming\.nativescript-cli\extensions\node_modules\nativescript-cloud\lib\services\cloud-platform-service.js:3:12)
    at CloudPlatformService.saveBuildInfoFile (C:\Users\bdtest.PROGRESS\AppData\Roaming\.nativescript-cli\extensions\node_modules\nativescript-cloud\lib\services\cloud-platform-service.js:62:16)
    at CloudBuildService.<anonymous> (C:\Users\bdtest.PROGRESS\AppData\Roaming\.nativescript-cli\extensions\node_modules\nativescript-cloud\lib\services\cloud-build-service.js:187:42)
    at Generator.next (<anonymous>)
    at fulfilled (C:\Users\bdtest.PROGRESS\AppData\Roaming\.nativescript-cli\extensions\node_modules\nativescript-cloud\lib\services\cloud-build-service.js:4:58)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```