### PR TITLE
fix: add validateDeviceApiLevel to cloud-bundle-validator-helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
 - '10'
+cache:
+  npm: false
 git:
   submodules: false
 install:

--- a/lib/cloud-android-bundle-validator-helper.ts
+++ b/lib/cloud-android-bundle-validator-helper.ts
@@ -18,7 +18,7 @@ export class CloudAndroidBundleValidatorHelper implements IAndroidBundleValidato
 	}
 
 	validateDeviceApiLevel(device: Mobile.IDevice, buildData: IBuildData): void {
-		return this.$bundleValidatorHelper.validateDeviceApiLevel(device, buildData);
+		throw new Error("validateDeviceApiLevel method is not implemented.");
 	}
 }
 

--- a/lib/cloud-android-bundle-validator-helper.ts
+++ b/lib/cloud-android-bundle-validator-helper.ts
@@ -2,7 +2,8 @@ export class CloudAndroidBundleValidatorHelper implements IAndroidBundleValidato
 	protected get $bundleValidatorHelper(): IAndroidBundleValidatorHelper {
 		return this.$nsCloudPolyfillService.getPolyfillObject<IAndroidBundleValidatorHelper>("androidBundleValidatorHelper", {
 			validateNoAab: () => { /* Mock */ },
-			validateRuntimeVersion: () => { /* Mock */ }
+			validateRuntimeVersion: () => { /* Mock */ },
+			validateDeviceApiLevel: () => { /* Mock */ }
 		});
 	}
 
@@ -14,6 +15,10 @@ export class CloudAndroidBundleValidatorHelper implements IAndroidBundleValidato
 
 	validateRuntimeVersion(projectData: IProjectData) {
 		return this.$bundleValidatorHelper.validateRuntimeVersion(projectData);
+	}
+
+	validateDeviceApiLevel(device: Mobile.IDevice, buildData: IBuildData): void {
+		return this.$bundleValidatorHelper.validateDeviceApiLevel(device, buildData);
 	}
 }
 


### PR DESCRIPTION
The `nativescript` is not correctly downloaded when installing the dependencies. It seems it is cached and travis relies on this cache in order to use it.
So, we need to set `cache: npm: false` inside `travis.yaml`. This way, `npm install` will always get the dependencies from github instead of the local cache.