### PR TITLE
fix: update nativescript-doctor to latest version

### DIFF
--- a/lib/services/cloud-codesign-service.ts
+++ b/lib/services/cloud-codesign-service.ts
@@ -68,6 +68,8 @@ export class CloudCodesignService extends CloudService implements ICloudCodesign
 	private async executeGeneration(codesignData: ICodesignData,
 		projectDir: string,
 		cloudOperationId: string): Promise<ICodesignResultData> {
+		throw new Error("Auto Generation is currently not available. Please follow the GitHub issue for further information: https://github.com/NativeScript/sidekick-feedback/issues/435");
+
 		const codesignInformationString = "generation of iOS certificate and provision files";
 		this.$logger.info(`Starting ${codesignInformationString}.`);
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "cookie": "0.3.1",
     "lodash": "4.17.4",
     "minimatch": "3.0.4",
-    "nativescript-doctor": "0.9.0",
+    "nativescript-doctor": "1.12.0",
     "node-forge": "0.7.0",
     "osenv": "0.1.4",
     "promise-retry": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "1.19.2",
+  "version": "1.19.3",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {


### PR DESCRIPTION
The currently used nativescript-doctor version is very old and it has non-direct dependency to the `natives` package, which does not work with latest Node.js versions. It needs to be updated every time when a new Node.js is released.
The latest nativescript-doctor version does not depend on natives package, so the errors with `natives` packages are not propagated anymore.

Fixes issue https://github.com/NativeScript/sidekick-feedback/issues/434