### PR TITLE
Add --androidReleaseStatus flag

### DIFF
--- a/docs/cloud-publish-android.md
+++ b/docs/cloud-publish-android.md
@@ -8,7 +8,7 @@ Builds the project in the cloud and then uploads the produced application packag
 
 Usage | Synopsis
 ---|---
-General | `$ tns cloud publish android <path to authentication.json> --accountId <Account Identifier> --key-store-path <File Path> --key-store-password <Password> [--env.*] --track <Track>`
+General | `$ tns cloud publish android <path to authentication.json> --accountId <Account Identifier> --key-store-path <File Path> --key-store-password <Password> [--env.*] --track <Track> [--androidReleaseStatus <Status>]`
 
 ### Arguments
 
@@ -22,6 +22,7 @@ General | `$ tns cloud publish android <path to authentication.json> --accountId
 * `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. For example: `--env.uglify --env.snapshot`.
 * `--sharedCloud` - Builds the application in the shared cloud instead of the private one. This option is valid only for users who have Private Cloud feature enabled.
 * `--track` - Specifies the Google Play release track for which to publish the application. In case the flag is not passed, the CLI will prompt you to specify it. In a non-interactive terminal, CLI defaults to 'beta' track.
+* `--androidReleaseStatus` - Specifies the Google Play release status. Acceptable values are `completed`, `draft`, `halted` and `inProgress`. The default value which will be used it `completed`.
 
 <% if(isHtml) { %>
 

--- a/lib/cloud-options-provider.ts
+++ b/lib/cloud-options-provider.ts
@@ -13,6 +13,7 @@ export class CloudOptionsProvider implements ICloudOptionsProvider {
 			workflow: { type: OptionType.Object, hasSensitiveValue: true },
 			vmTemplateName: { type: OptionType.String, hasSensitiveValue: false },
 			track: { type: OptionType.String, default: DEFAULT_ANDROID_PUBLISH_TRACK, hasSensitiveValue: false },
+			androidReleaseStatus: { type: OptionType.String, hasSensitiveValue: false },
 			appleApplicationSpecificPassword: { type: OptionType.String, hasSensitiveValue: true },
 			appleSessionBase64: { type: OptionType.String, hasSensitiveValue: true },
 			otp: { type: OptionType.String, hasSensitiveValue: false },

--- a/lib/commands/cloud-publish.ts
+++ b/lib/commands/cloud-publish.ts
@@ -78,6 +78,7 @@ export class CloudPublishAndroid extends CloudPublish implements ICommand {
 			packagePaths: [packagePath],
 			sharedCloud: this.$options.sharedCloud,
 			projectDir: this.$projectData.projectDir,
+			androidReleaseStatus: this.$options.androidReleaseStatus
 		});
 	}
 }

--- a/lib/definitions/cloud-options.d.ts
+++ b/lib/definitions/cloud-options.d.ts
@@ -2,6 +2,7 @@
  * Describes additional -- flags that can be passed to cloud commands.
  */
 interface ICloudOptions extends IOptions, ISharedCloud {
+	androidReleaseStatus: string;
 	accountId: string;
 	apiVersion: string;
 	local: boolean;

--- a/lib/definitions/cloud-publish-service.d.ts
+++ b/lib/definitions/cloud-publish-service.d.ts
@@ -66,6 +66,11 @@ interface IGooglePlayPublishData extends IPublishDataCore, IOptionalAndroidTrack
 	 * Path to local json file generated through Google API Console.
 	 */
 	pathToAuthJson: string;
+
+	/**
+	 * The desired status of this release. Acceptable values are: completed, draft, halted, inProgress.
+	 */
+	androidReleaseStatus?: string;
 }
 
 /**

--- a/lib/definitions/server/server-build-service.d.ts
+++ b/lib/definitions/server/server-build-service.d.ts
@@ -86,6 +86,7 @@ interface IPublishCredentials extends IApple2FAOptions {
 }
 
 interface IPublishRequestData extends IPlatform, IPackagePaths, IOptionalAndroidTrack, IOptionalTeamIdentifier, ICloudOperationId {
+	androidReleaseStatus?: string;
 	credentials: IPublishCredentials;
 	appIdentifier?: string;
 	sharedCloud?: boolean;

--- a/lib/services/cloud-publish-service.ts
+++ b/lib/services/cloud-publish-service.ts
@@ -76,7 +76,8 @@ export class CloudPublishService extends CloudService implements ICloudPublishSe
 				},
 				packagePaths: publishData.packagePaths,
 				platform: this.$devicePlatformsConstants.Android,
-				track: publishData.track
+				track: publishData.track,
+				androidReleaseStatus: publishData.androidReleaseStatus,
 			}, publishData, this.getAndroidError.bind(this));
 		});
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "1.19.3",
+  "version": "1.20.0",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {


### PR DESCRIPTION
The new google play publish api requires a release status. We need to
provide a way to pass this status to our build machines.