### PR TITLE
fix: temp files should be deleted

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -62,6 +62,7 @@ $injector.require("nsCloudEncryptionSettingsService", path.join(__dirname, "serv
 $injector.require("nsCloudEncryptionService", path.join(__dirname, "services", "cloud-encryption-service"));
 $injector.require("nsCloudAppleService", path.join(__dirname, "services", "cloud-apple-service"));
 $injector.require("nsCloudPlatformService", path.join(__dirname, "services", "cloud-platform-service"));
+$injector.require("nsCloudTempService", path.join(__dirname, "services", "temp-service"));
 
 // Commands.
 $injector.requireCommand("config|*get", path.join(__dirname, "commands", "config", "config-get"));

--- a/lib/services/eula-service-base.ts
+++ b/lib/services/eula-service-base.ts
@@ -1,6 +1,5 @@
 import * as path from "path";
 import { EulaConstants } from "../constants";
-import * as temp from "temp";
 
 export abstract class EulaServiceBase implements IEulaService {
 	private isEulaDownloadedInCurrentProcess = false;
@@ -11,7 +10,8 @@ export abstract class EulaServiceBase implements IEulaService {
 		private $logger: ILogger,
 		private $nsCloudHashService: IHashService,
 		private $settingsService: ISettingsService,
-		private $userSettingsService: IUserSettingsService) { }
+		private $userSettingsService: IUserSettingsService,
+		private $nsCloudTempService: ITempService) { }
 
 	// Exposed for Sidekick
 	public getEulaData(): Promise<IEulaData> {
@@ -75,8 +75,7 @@ export abstract class EulaServiceBase implements IEulaService {
 		}
 
 		try {
-			const tempEulaPath = temp.path({ prefix: "eula", suffix: ".pdf" });
-			temp.track();
+			const tempEulaPath = await this.$nsCloudTempService.path({ prefix: "eula", suffix: ".pdf" });
 
 			this.$logger.trace(`Downloading EULA to ${this.getPathToEula()}.`);
 

--- a/lib/services/eula-service.ts
+++ b/lib/services/eula-service.ts
@@ -8,8 +8,9 @@ export class EulaService extends EulaServiceBase implements IEulaService {
 		$logger: ILogger,
 		$nsCloudHashService: IHashService,
 		$settingsService: ISettingsService,
-		$userSettingsService: IUserSettingsService) {
-		super($fs, $httpClient, $nsCloudLockService, $logger, $nsCloudHashService, $settingsService, $userSettingsService);
+		$userSettingsService: IUserSettingsService,
+		$nsCloudTempService: ITempService) {
+		super($fs, $httpClient, $nsCloudLockService, $logger, $nsCloudHashService, $settingsService, $userSettingsService, $nsCloudTempService);
 	}
 
 	protected getAcceptedEulaHashPropertyName(): string {

--- a/lib/services/kinvey-eula-service.ts
+++ b/lib/services/kinvey-eula-service.ts
@@ -9,8 +9,9 @@ export class KinveyEulaService extends EulaServiceBase implements IEulaService {
 		$logger: ILogger,
 		$nsCloudHashService: IHashService,
 		$settingsService: ISettingsService,
-		$userSettingsService: IUserSettingsService) {
-		super($fs, $httpClient, $nsCloudLockService, $logger, $nsCloudHashService, $settingsService, $userSettingsService);
+		$userSettingsService: IUserSettingsService,
+		$nsCloudTempService: ITempService) {
+		super($fs, $httpClient, $nsCloudLockService, $logger, $nsCloudHashService, $settingsService, $userSettingsService, $nsCloudTempService);
 	}
 
 	protected getAcceptedEulaHashPropertyName(): string {

--- a/lib/services/policy-service.ts
+++ b/lib/services/policy-service.ts
@@ -1,4 +1,3 @@
-import * as temp from "temp";
 import { isUrl } from "../helpers";
 
 export class PolicyService implements IPolicyService {
@@ -8,7 +7,8 @@ export class PolicyService implements IPolicyService {
 		private $fs: IFileSystem,
 		private $httpClient: Server.IHttpClient,
 		private $nsCloudHashService: IHashService,
-		private $userSettingsService: IUserSettingsService) { }
+		private $userSettingsService: IUserSettingsService,
+		private $nsCloudTempService: ITempService) { }
 
 	public async shouldAcceptPolicy(data: IAcceptPolicyData): Promise<boolean> {
 		const shouldAskToAccept = await this.shouldAskToAcceptPolicy(data.policyName);
@@ -58,8 +58,7 @@ export class PolicyService implements IPolicyService {
 		} else if (data.policyUri) {
 			let fileHash = data.policyUri;
 			if (isUrl(data.policyUri)) {
-				const tempPolicyFile = temp.path({ prefix: data.policyName, suffix: ".txt" });
-				temp.track();
+				const tempPolicyFile = await this.$nsCloudTempService.path({ prefix: data.policyName, suffix: ".txt" });
 				await this.$httpClient.httpRequest({
 					url: data.policyUri,
 					pipeTo: this.$fs.createWriteStream(tempPolicyFile)

--- a/lib/services/temp-service.ts
+++ b/lib/services/temp-service.ts
@@ -1,0 +1,34 @@
+import * as temp from "temp";
+
+export class CloudTempService implements ITempService {
+	private tempService: ITempService;
+
+	constructor(private $logger: ILogger,
+		private $injector: IInjector) {
+		try {
+			const tempService = this.$injector.resolve<ITempService>("tempService");
+			this.tempService = tempService;
+		} catch (err) {
+			this.$logger.trace("Unable to resolve tempService in nativescript-cloud. Will use basic temp module");
+			temp.track();
+		}
+	}
+
+	public async mkdirSync(affixes: string): Promise<string> {
+		if (this.tempService) {
+			return this.tempService.mkdirSync(affixes);
+		}
+
+		return temp.mkdirSync(affixes);
+	}
+
+	public async path(options: ITempPathOptions): Promise<string> {
+		if (this.tempService) {
+			return this.tempService.path(options);
+		}
+
+		return temp.path(options);
+	}
+}
+
+$injector.register("nsCloudTempService", CloudTempService);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-cloud",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "Used for cloud support in NativeScript CLI",
   "main": "lib/bootstrap.js",
   "scripts": {

--- a/test/services/eula-service.ts
+++ b/test/services/eula-service.ts
@@ -4,6 +4,8 @@ import { Yok } from "nativescript/lib/common/yok";
 import { assert } from "chai";
 import { EulaConstants } from "../../lib/constants";
 import { NsCouldLockService } from "../../lib/services/lock-service";
+import * as temp from "temp";
+temp.track();
 
 interface IEulaTestData {
 	testName: string;
@@ -78,6 +80,11 @@ describe("eulaService", () => {
 		testInjector.register("nsCloudLockService", NsCouldLockService);
 
 		testInjector.register("nsCloudHashService", HashService);
+
+		testInjector.register("nsCloudTempService", {
+			mkdirSync: async (affixes: string): Promise<string> => temp.mkdirSync(affixes),
+			path: async (options: ITempPathOptions): Promise<string> => temp.path(options)
+		});
 
 		return testInjector;
 	};


### PR DESCRIPTION
Currently temp files are not deleted in some cases. Use the tempService from CLI 6.4 or fallback to `temp` module in case CLI is older.

Must be merged after https://github.com/NativeScript/nativescript-cli/pull/5238